### PR TITLE
Optimize token validity checks

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -11,24 +11,58 @@
 
 <script setup>
 import { useGlobalStore } from "~/stores/global";
-import { ref, onMounted } from "vue";
+import { ref, onMounted, onBeforeUnmount, watch } from "vue";
 
 const authStore = useGlobalStore();
 const isInitialized = ref(false);
+let tokenCheckTimeout;
+
+function scheduleTokenCheck() {
+  if (tokenCheckTimeout) {
+    clearTimeout(tokenCheckTimeout);
+    tokenCheckTimeout = null;
+  }
+
+  const token = process.client ? localStorage.getItem("token") : null;
+  if (!token) return;
+
+  let delay = 30 * 60 * 1000; // по умолчанию раз в 30 минут
+  try {
+    const payload = JSON.parse(atob(token.split(".")[1]));
+    if (payload?.exp) {
+      const timeToExpiry = payload.exp * 1000 - Date.now();
+      // проверяем токен за 5 минут до истечения срока
+      delay = Math.max(timeToExpiry - 5 * 60 * 1000, 5 * 60 * 1000);
+    }
+  } catch (e) {
+    // игнорируем ошибки парсинга и используем интервал по умолчанию
+  }
+
+  tokenCheckTimeout = setTimeout(async () => {
+    try {
+      await authStore.getUser();
+    } finally {
+      scheduleTokenCheck();
+    }
+  }, delay);
+}
 
 onMounted(async () => {
-  // Выполняем инициализацию
   await authStore.initialize();
   console.log("App.vue: Initialize complete, currentUser:", authStore.currentUser);
-  isInitialized.value = true; // Устанавливаем флаг после завершения
+  isInitialized.value = true;
+  scheduleTokenCheck();
+});
 
-  // Периодическая проверка (раз в 30 минут)
-  setInterval(async () => {
-    console.log("Periodic check");
-    if (localStorage.getItem("token") && !authStore.currentUser) {
-      await authStore.getUser();
-    }
-  }, 30 * 60 * 1000);
+// Перезапускаем проверку при изменении токена (логин/логаут)
+watch(() => authStore.token, () => {
+  scheduleTokenCheck();
+});
+
+onBeforeUnmount(() => {
+  if (tokenCheckTimeout) {
+    clearTimeout(tokenCheckTimeout);
+  }
 });
 </script>
 


### PR DESCRIPTION
## Summary
- schedule token validation with adaptive timeout instead of fixed interval
- clear validation timer on unmount and reschedule on token updates to avoid resource leaks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b41dc4904c8320a0b34b273377c985