### PR TITLE
refactor: improve hero and layout responsiveness

### DIFF
--- a/components/quotes/Quote.vue
+++ b/components/quotes/Quote.vue
@@ -1,46 +1,15 @@
 <script setup lang="ts">
-defineProps({
-  title: '',
-  author: '',
-  text: ''
-})
+const { title, author, text } = defineProps<{
+  title: string
+  author: string
+  text: string
+}>()
 </script>
 
 <template>
-<div class="item">
-  <h2 class="text-1xl">{{title}}</h2>
-  <p>{{text}}</p>
-  <span>{{author}}</span>
-</div>
+  <div class="flex flex-col justify-between p-5 h-40 w-full max-w-md mx-auto rounded-2xl border border-gray-200 shadow">
+    <h2 class="text-lg font-bold text-center">{{ title }}</h2>
+    <p class="text-base text-center">{{ text }}</p>
+    <span class="italic text-sm text-right">{{ author }}</span>
+  </div>
 </template>
-
-<style scoped>
-.item{
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  border: 1px solid #eaeaea;
-  padding: 20px;
-  height: 150px;
-  border-radius: 20px;
-  width: 800px;
-  box-shadow:
-      0 4px 8px rgba(0, 0, 0, 0.1);  /* Мягкая тень снизу */
-      /* Глубокая тень для объёмности */
-
-  h2{
-    font-size: 18px !important;
-    font-weight: 700;
-    text-align: center;
-  }
-  p{
-    font-size: 16px !important;
-    text-align: center;
-  }
-  span{
-    font-style: italic;
-    font-size: 12px;
-    text-align: end;
-  }
-}
-</style>

--- a/components/quotes/Quotes.vue
+++ b/components/quotes/Quotes.vue
@@ -1,16 +1,21 @@
 <script setup>
-import {onMounted, ref} from "vue"
+import { onMounted, ref } from "vue"
 import Quote from "~/components/quotes/Quote.vue";
 const containerRef = ref(null)
 const slides = ref(Array.from({ length: 10 }))
 const swiper = useSwiper(containerRef, {
-
   loop: true,
   autoplay: {
     delay: 5000,
   },
   spaceBetween: 20,
-  slidesPerView: 5,
+  slidesPerView: 1,
+  breakpoints: {
+    640: { slidesPerView: 2 },
+    768: { slidesPerView: 3 },
+    1024: { slidesPerView: 4 },
+    1280: { slidesPerView: 5 },
+  },
   direction: 'horizontal',
 })
 const datas = ref([
@@ -87,16 +92,17 @@ onMounted(()=>{
   <div class="quotes main">
     <h1 class="text-4xl font-bold">Цитаты</h1>
     <ClientOnly>
-      <swiper-container ref="containerRef" :init="false">
+      <swiper-container ref="containerRef" :init="false" class="w-full max-w-screen mx-auto">
         <swiper-slide
             v-for="(slide, idx) in randomBooks"
             :key="idx"
+            class="min-w-0"
             style="background-color: #F0F4F8;"
         >
-          <quote
-          :author="slide.author"
-          :text="slide.text"
-          :title="slide.title"
+          <Quote
+            :author="slide.author"
+            :text="slide.text"
+            :title="slide.title"
           />
         </swiper-slide>
       </swiper-container>
@@ -127,8 +133,4 @@ swiper-slide {
   font-family: 'Roboto', sans-serif;
 }
 
-quote {
-  width: 100%;
-  max-width: 300px;
-}
 </style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -5,9 +5,11 @@ import Footer from "~/components/layout/Footer.vue";
 </script>
 
 <template>
-<Header/>
-  <slot></slot>
-  <Footer/>
+  <Header />
+  <div class="container mx-auto px-4 sm:px-6">
+    <slot />
+  </div>
+  <Footer />
 </template>
 
 <style scoped>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -31,9 +31,8 @@ const fallingElements = ref([])
 onMounted(() => {
   fallingElements.value = Array.from({ length: 10 }, (_, index) => ({
     id: index,
-    left: `${Math.random() * 100}%`,
-    delay: `${Math.random() * 5}s`,
-    size: `${20 + Math.random() * 40}px`
+    left: `${5 + Math.random() * 90}%`,
+    delay: `${Math.random() * 5}s`
   }))
 
   nextTick(() => {
@@ -49,25 +48,24 @@ onMounted(() => {
 <template>
   <div>
     <!-- Hero Section -->
-    <div class="relative h-[80vh] w-full bg-image-my bg-cover bg-center bg-no-repeat -mt-[170px] rounded-b-2xl">
+    <div class="relative w-full min-h-screen sm:min-h-[80vh] bg-image-my bg-cover bg-center bg-no-repeat mt-0 sm:-mt-[170px] rounded-b-2xl">
       <div class="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-black/30 text-white text-center p-5 rounded-2xl shadow-[0_0_10px_rgba(0,0,0,0.7)] animate-fadeIn">
-        <h1 class="text-4xl sm:text-5xl font-bold mb-2">Добро пожаловать в Библиотеку</h1>
-        <h1 class="text-4xl sm:text-5xl font-bold mb-4">"Эпоха Знаний"</h1>
-        <p class="text-xl sm:text-2xl animate-fadeIn delay-500">Место, где живут истории и рождаются идеи</p>
+        <h1 class="text-2xl sm:text-4xl md:text-5xl font-bold mb-2">Добро пожаловать в Библиотеку</h1>
+        <h1 class="text-2xl sm:text-4xl md:text-5xl font-bold mb-4">"Эпоха Знаний"</h1>
+        <p class="text-lg sm:text-xl md:text-2xl animate-fadeIn delay-500">Место, где живут истории и рождаются идеи</p>
       </div>
     </div>
 
     <!-- About Section -->
-    <section class="relative py-12 sm:py-16 text-center overflow-hidden">
+    <section class="relative py-12 sm:py-16 text-center">
       <div class="absolute inset-0 pointer-events-none -z-10">
         <div
             v-for="element in fallingElements"
             :key="element.id"
-            class="absolute top-5 opacity-0 animate-fall"
+            class="absolute top-5 opacity-0 animate-fall text-lg sm:text-xl md:text-3xl"
             :style="{
               left: element.left,
-              animationDelay: element.delay,
-              fontSize: element.size
+              animationDelay: element.delay
             }"
         >
           📖
@@ -105,6 +103,7 @@ onMounted(() => {
 
       <ClientOnly>
         <swiper-container
+            class="w-full max-w-screen mx-auto"
             init="false"
             loop="true"
             autoplay-delay="3000"
@@ -116,7 +115,7 @@ onMounted(() => {
             "1024": {"slidesPerView": 5}
           }'
         >
-          <swiper-slide v-for="(slide, idx) in statistics" :key="idx" class="bg-gray-50">
+          <swiper-slide v-for="(slide, idx) in statistics" :key="idx" class="bg-gray-50 min-w-0">
             <div class="flex flex-col items-center justify-between gap-3 p-4">
               <img :src="slide.imageSrc" alt="" class="w-12 h-12">
               <h3 class="font-medium text-lg">{{ slide.title }}</h3>
@@ -128,7 +127,7 @@ onMounted(() => {
     </section>
 
     <!-- Sections with Books -->
-    <div class="container mx-auto px-4 sm:px-6">
+    <div>
       <NuxtLink to="/" class="block mb-6">
         <h1 class="text-3xl sm:text-4xl font-bold text-center">Новинки</h1>
       </NuxtLink>
@@ -150,7 +149,7 @@ onMounted(() => {
     </div>
 
     <!-- Top Users Section -->
-    <div class="max-w-7xl mx-auto px-4 py-6 sm:py-8">
+    <div class="max-w-7xl py-6 sm:py-8">
       <h2 class="text-2xl font-bold text-gray-900 mb-4">Топовые пользователи</h2>
 
       <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">


### PR DESCRIPTION
## Summary
- make layout container-based instead of overflow hacks
- adapt hero section to be responsive and accessible
- limit falling icons and slider widths to avoid horizontal overflow
- fix quote components with responsive sizing and swiper breakpoints
- ensure quote text props render properly

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b423f31a8483209d9b76ffd25e5fa8