### PR TITLE
Integrate Quotes carousel on index page

### DIFF
--- a/components/quotes/Quote.vue
+++ b/components/quotes/Quote.vue
@@ -1,15 +1,36 @@
 <script setup lang="ts">
+import { ref, onMounted, nextTick } from 'vue'
+
 defineProps({
   title: '',
   author: '',
   text: ''
 })
+
+const containerRef = ref<HTMLElement | null>(null)
+const textRef = ref<HTMLElement | null>(null)
+
+const fitText = () => {
+  const container = containerRef.value
+  const textEl = textRef.value
+  if (!container || !textEl) return
+  let fontSize = parseFloat(getComputedStyle(textEl).fontSize)
+  while (container.scrollHeight > container.clientHeight && fontSize > 12) {
+    fontSize -= 1
+    textEl.style.fontSize = `${fontSize}px`
+  }
+}
+
+onMounted(async () => {
+  await nextTick()
+  fitText()
+})
 </script>
 
 <template>
-<div class="item">
+<div class="item" ref="containerRef">
   <h2 class="text-1xl">{{title}}</h2>
-  <p>{{text}}</p>
+  <p ref="textRef">{{text}}</p>
   <span>{{author}}</span>
 </div>
 </template>
@@ -19,28 +40,31 @@ defineProps({
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  border: 1px solid #eaeaea;
-  padding: 20px;
-  height: 150px;
-  border-radius: 20px;
-  width: 800px;
-  box-shadow:
-      0 4px 8px rgba(0, 0, 0, 0.1);  /* Мягкая тень снизу */
-      /* Глубокая тень для объёмности */
+    border: 1px solid #eaeaea;
+    padding: 20px;
+    border-radius: 20px;
+    width: 100%;
+    height: 150px;
+    overflow: hidden;
+    box-shadow:
+        0 4px 8px rgba(0, 0, 0, 0.1);  /* Мягкая тень снизу */
+        /* Глубокая тень для объёмности */
 
-  h2{
-    font-size: 18px !important;
-    font-weight: 700;
-    text-align: center;
+    h2{
+      font-size: 18px !important;
+      font-weight: 700;
+      text-align: center;
+    }
+    p{
+      font-size: 16px !important;
+      text-align: center;
+      overflow-wrap: break-word;
+      flex-grow: 1;
+    }
+    span{
+      font-style: italic;
+      font-size: 12px;
+      text-align: end;
+    }
   }
-  p{
-    font-size: 16px !important;
-    text-align: center;
-  }
-  span{
-    font-style: italic;
-    font-size: 12px;
-    text-align: end;
-  }
-}
-</style>
+  </style>

--- a/components/quotes/Quotes.vue
+++ b/components/quotes/Quotes.vue
@@ -116,19 +116,16 @@ onMounted(()=>{
 }
 
 
-swiper-slide {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-size: 18px;
-  height: 20vh;
-  font-size: 4rem;
-  font-weight: bold;
-  font-family: 'Roboto', sans-serif;
-}
+  :deep(swiper-slide) {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: auto;
+    font-family: 'Roboto', sans-serif;
+  }
 
-quote {
-  width: 100%;
-  max-width: 300px;
-}
+  :deep(quote) {
+    width: 100%;
+    max-width: 300px;
+  }
 </style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -3,7 +3,7 @@ import { ref, onMounted, nextTick } from "vue";
 import NewBooks from "~/components/books/NewBooks.vue";
 import EducationBooks from "~/components/books/EducationBooks.vue";
 import {useGlobalStore} from "~/stores/global";
-import Quote from "~/components/quotes/Quote.vue";
+import Quotes from "~/components/quotes/Quotes.vue";
 
 const store = useGlobalStore()
 const statistics = ref([
@@ -134,14 +134,14 @@ onMounted(() => {
       </NuxtLink>
       <NewBooks />
 
-      <Quote />
+      <Quotes />
 
       <NuxtLink to="/" class="block my-6 sm:my-8">
         <h1 class="text-3xl sm:text-4xl font-bold text-center">Образовательные книги</h1>
       </NuxtLink>
       <EducationBooks />
 
-      <Quote />
+      <Quotes />
 
       <NuxtLink to="/" class="block my-6 sm:my-8">
         <h1 class="text-3xl sm:text-4xl font-bold text-center">Случайные книги</h1>


### PR DESCRIPTION
## Summary
- replace Quote import with Quotes carousel component
- swap Quote placeholders for Quotes carousel in home page book sections
- auto-scale quote text to fit within its card and avoid clipping
- ensure swiper and quote tags receive styles via deep selectors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b436ce95908320a349843256803329