### PR TITLE
Add pagination controls to book listings

### DIFF
--- a/components/books/Books.vue
+++ b/components/books/Books.vue
@@ -1,32 +1,82 @@
 <script setup>
-import { ref, onMounted, computed } from 'vue';
+import { ref, onMounted } from 'vue';
 import { useBooks } from '~/composables/useBooks.js';
 
 const books = ref([]);
+const isInitialLoading = ref(true);
+const isLoadingMore = ref(false);
+const hasMore = ref(true);
+const page = ref(1);
+const perPage = 12;
+
 const { fetchRandomBooks } = useBooks();
 
-// Загружаем книги при монтировании компонента
-const loadBooks = async () => {
-  books.value = await fetchRandomBooks();
+const loadInitialBooks = async () => {
+  isInitialLoading.value = true;
+  try {
+    const data = await fetchRandomBooks({ perPage, page: page.value });
+    books.value = data;
+    if (data.length < perPage) {
+      hasMore.value = false;
+    }
+  } catch (error) {
+    console.error('Ошибка при загрузке книг:', error);
+    hasMore.value = false;
+  } finally {
+    isInitialLoading.value = false;
+  }
 };
+
+const loadMoreBooks = async () => {
+  if (!hasMore.value || isLoadingMore.value) {
+    return;
+  }
+  isLoadingMore.value = true;
+  const nextPage = page.value + 1;
+  try {
+    const data = await fetchRandomBooks({ perPage, page: nextPage });
+    if (data.length === 0) {
+      hasMore.value = false;
+      return;
+    }
+    books.value = [...books.value, ...data];
+    page.value = nextPage;
+    if (data.length < perPage) {
+      hasMore.value = false;
+    }
+  } catch (error) {
+    console.error('Ошибка при догрузке книг:', error);
+  } finally {
+    isLoadingMore.value = false;
+  }
+};
+
 onMounted(() => {
-  loadBooks();
+  loadInitialBooks();
 });
 </script>
 
 <template>
-  <div v-if="books.length === 0">
-    <p class="load">Загрузка...</p>
-  </div>
-  <div v-else>
-    <div class="books">
-      <div v-for="book in books" :key="book.title">
-        <books-item
-            :title="book.title"
-            :author="book.author"
-            :image-src="book.image"
-            :id ="book.id"
-        />
+  <div>
+    <div v-if="isInitialLoading">
+      <p class="load">Загрузка...</p>
+    </div>
+    <div v-else>
+      <div class="books">
+        <div v-for="book in books" :key="book.title">
+          <books-item
+              :title="book.title"
+              :author="book.author"
+              :image-src="book.image"
+              :id ="book.id"
+          />
+        </div>
+      </div>
+      <div class="button-container" v-if="hasMore">
+        <button type="button" @click="loadMoreBooks" :disabled="isLoadingMore">
+          <span v-if="isLoadingMore">Загрузка...</span>
+          <span v-else>Загрузить еще</span>
+        </button>
       </div>
     </div>
   </div>

--- a/components/books/EducationBooks.vue
+++ b/components/books/EducationBooks.vue
@@ -1,38 +1,83 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
-import {educationBooks} from '~/composables/useBooks.js';
+import type { Ref } from 'vue';
+import { educationBooks } from '~/composables/useBooks.js';
 
-const books = ref([]);
+const books = ref<any[]>([]);
+const isInitialLoading: Ref<boolean> = ref(true);
+const isLoadingMore: Ref<boolean> = ref(false);
+const hasMore: Ref<boolean> = ref(true);
+const page: Ref<number> = ref(1);
+const perPage = 12;
 
 const { fetchRandomBooks } = educationBooks();
-// Загружаем книги при монтировании компонента
-const loadBooks = async () => {
+
+const loadInitialBooks = async () => {
+  isInitialLoading.value = true;
   try {
-    const data = await fetchRandomBooks();
-    console.log('Полученные данные:', data); // Для отладки
+    const data = await fetchRandomBooks({ perPage, page: page.value });
     books.value = data;
+    if (data.length < perPage) {
+      hasMore.value = false;
+    }
   } catch (error) {
-    console.error('Ошибка при загрузке книг:', error);
+    console.error('Ошибка при загрузке образовательных книг:', error);
+    hasMore.value = false;
+  } finally {
+    isInitialLoading.value = false;
   }
 };
+
+const loadMoreBooks = async () => {
+  if (!hasMore.value || isLoadingMore.value) {
+    return;
+  }
+  isLoadingMore.value = true;
+  const nextPage = page.value + 1;
+  try {
+    const data = await fetchRandomBooks({ perPage, page: nextPage });
+    if (data.length === 0) {
+      hasMore.value = false;
+      return;
+    }
+    books.value = [...books.value, ...data];
+    page.value = nextPage;
+    if (data.length < perPage) {
+      hasMore.value = false;
+    }
+  } catch (error) {
+    console.error('Ошибка при догрузке образовательных книг:', error);
+  } finally {
+    isLoadingMore.value = false;
+  }
+};
+
 onMounted(() => {
-  loadBooks();
+  loadInitialBooks();
 });
 </script>
 
 <template>
-  <div v-if="books.length === 0">
-    <p class="load">Загрузка...</p>
-  </div>
-  <div v-else>
-    <div class="books">
-      <div v-for="book in books" :key="book.title">
-        <books-item
-            :title="book.title"
-            :author="book.author"
-            :image-src="book.image"
-            :id ="book.id"
-        />
+  <div>
+    <div v-if="isInitialLoading">
+      <p class="load">Загрузка...</p>
+    </div>
+    <div v-else>
+      <div class="books">
+        <div v-for="book in books" :key="book.title">
+          <books-item
+              :title="book.title"
+              :author="book.author"
+              :image-src="book.image"
+              :id ="book.id"
+          />
+        </div>
+      </div>
+      <div class="button-container" v-if="hasMore">
+        <button type="button" @click="loadMoreBooks" :disabled="isLoadingMore">
+          <span v-if="isLoadingMore">Загрузка...</span>
+          <span v-else>Загрузить еще</span>
+        </button>
       </div>
     </div>
   </div>

--- a/components/books/NewBooks.vue
+++ b/components/books/NewBooks.vue
@@ -1,42 +1,84 @@
 <template>
-  <div v-if="books.length === 0">
-    <p class="load">Загрузка...</p>
-  </div>
-  <div v-else>
-    <div class="books">
-      <div v-for="book in books" :key="book.title">
-        <books-item
-            :title="book.title"
-            :author="book.author"
-            :image-src="book.image"
-            :id ="book.id"
-        />
-      </div>
+  <div>
+    <div v-if="isInitialLoading">
+      <p class="load">Загрузка...</p>
     </div>
-    <div class="button-container">
+    <div v-else>
+      <div class="books">
+        <div v-for="book in books" :key="book.title">
+          <books-item
+              :title="book.title"
+              :author="book.author"
+              :image-src="book.image"
+              :id ="book.id"
+          />
+        </div>
+      </div>
+      <div class="button-container" v-if="hasMore">
+        <button type="button" @click="loadMoreBooks" :disabled="isLoadingMore">
+          <span v-if="isLoadingMore">Загрузка...</span>
+          <span v-else>Загрузить еще</span>
+        </button>
+      </div>
     </div>
   </div>
 </template>
 
 <script setup>
 import { ref, onMounted } from 'vue';
-import {useNewBook} from '~/composables/useBooks.js';
+import { useNewBook } from '~/composables/useBooks.js';
 
 const books = ref([]);
+const isInitialLoading = ref(true);
+const isLoadingMore = ref(false);
+const hasMore = ref(true);
+const page = ref(1);
+const perPage = 12;
 
 const { fetchRandomBooks } = useNewBook();
-// Загружаем книги при монтировании компонента
-const loadBooks = async () => {
+
+const loadInitialBooks = async () => {
+  isInitialLoading.value = true;
   try {
-    const data = await fetchRandomBooks();
-    console.log('Полученные данные:', data); // Для отладки
+    const data = await fetchRandomBooks({ perPage, page: page.value });
     books.value = data;
+    if (data.length < perPage) {
+      hasMore.value = false;
+    }
   } catch (error) {
-    console.error('Ошибка при загрузке книг:', error);
+    console.error('Ошибка при загрузке новых книг:', error);
+    hasMore.value = false;
+  } finally {
+    isInitialLoading.value = false;
   }
 };
+
+const loadMoreBooks = async () => {
+  if (!hasMore.value || isLoadingMore.value) {
+    return;
+  }
+  isLoadingMore.value = true;
+  const nextPage = page.value + 1;
+  try {
+    const data = await fetchRandomBooks({ perPage, page: nextPage });
+    if (data.length === 0) {
+      hasMore.value = false;
+      return;
+    }
+    books.value = [...books.value, ...data];
+    page.value = nextPage;
+    if (data.length < perPage) {
+      hasMore.value = false;
+    }
+  } catch (error) {
+    console.error('Ошибка при догрузке новых книг:', error);
+  } finally {
+    isLoadingMore.value = false;
+  }
+};
+
 onMounted(() => {
-  loadBooks();
+  loadInitialBooks();
 });
 </script>
 

--- a/composables/useBooks.js
+++ b/composables/useBooks.js
@@ -1,13 +1,18 @@
 // useBooks.js
 const apiKey = 'AIzaSyAcwU-p-csUT5UbMbRKBuss_N5jb4A4M0o';
 export const useBooks = () => {
-    const fetchRandomBooks = async () => {
+    const fetchRandomBooks = async ({ perPage = 20, page = 1 } = {}) => {
         try {
             // Используйте свой API-ключ Google Books (получить его в Google Cloud Console)
             const keywords = ['minima', 'quo', 'voluptatum', 'est'];
             const randomKeyword = keywords[Math.floor(Math.random() * keywords.length)];
             // Делаем запрос к Google Books API
-            const response = await fetch(`http://127.0.0.1:8000/api/books?genre=${randomKeyword}`);
+            const params = new URLSearchParams({
+                genre: randomKeyword,
+                perPage: String(perPage),
+                page: String(page)
+            });
+            const response = await fetch(`http://127.0.0.1:8000/api/books?${params.toString()}`);
             const data = await response.json();
             if (!data || data.data.length === 0) {
                 return [];
@@ -22,9 +27,14 @@ export const useBooks = () => {
     return { fetchRandomBooks };
 };
 export const useNewBook = () => {
-    const fetchRandomBooks = async () => {
+    const fetchRandomBooks = async ({ perPage = 20, page = 1 } = {}) => {
         try {
-            const response = await fetch(`http://127.0.0.1:8000/api/books?sort=newest`);
+            const params = new URLSearchParams({
+                sort: 'newest',
+                perPage: String(perPage),
+                page: String(page)
+            });
+            const response = await fetch(`http://127.0.0.1:8000/api/books?${params.toString()}`);
             const data = await response.json();
             console.log('books111', data.data)
             if (!data || data.data.length === 0) {
@@ -39,9 +49,14 @@ export const useNewBook = () => {
     return { fetchRandomBooks };
 };
 export const educationBooks = () =>{
-    const fetchRandomBooks = async () => {
+    const fetchRandomBooks = async ({ perPage = 20, page = 1 } = {}) => {
         try {
-            const response = await fetch(`http://127.0.0.1:8000/api/books?genre=quo`);
+            const params = new URLSearchParams({
+                genre: 'quo',
+                perPage: String(perPage),
+                page: String(page)
+            });
+            const response = await fetch(`http://127.0.0.1:8000/api/books?${params.toString()}`);
             const data = await response.json();
             console.log('books111', data.data)
             if (!data || data.data.length === 0) {


### PR DESCRIPTION
## Summary
- add per-page and page query parameters to book-fetching composables
- update book listing components to request paginated data and provide incremental loading indicators

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d92a374ed48320b5be6ffaaf7ddd58