### PR TITLE
Refine catalog pagination to use page-based requests

### DIFF
--- a/stores/book.ts
+++ b/stores/book.ts
@@ -10,12 +10,25 @@ export const useBookStore = defineStore('books', {
         comments: []
     }),
     actions: {
-        async get_books(startIndex :number, genre :string){
+        async get_books(perPage: number, genre: string, page: number){
             try{
-                const response = await fetch(`http://127.0.0.1:8000/api/books?perPage=${startIndex}&genre=${genre}`)
+                const params = new URLSearchParams({
+                    perPage: String(perPage),
+                    page: String(page),
+                });
+                if (genre) {
+                    params.append('genre', genre);
+                }
+                const response = await fetch(`http://127.0.0.1:8000/api/books?${params.toString()}`)
                 const data = await response.json();
-                this.books = data.data
-                return
+                const books = Array.isArray(data.data) ? data.data : [];
+                let booksSlice = books;
+                if (books.length > perPage) {
+                    const start = (page - 1) * perPage;
+                    booksSlice = books.slice(start, start + perPage);
+                }
+                this.books = page === 1 ? booksSlice : [...this.books, ...booksSlice];
+                return booksSlice;
             }catch (error){
              console.error(error)
             }


### PR DESCRIPTION
## Summary
- switch the catalog page to a fixed 40-item page size with an explicit page counter
- extend the book store action to accept a page parameter, slice the response, and append subsequent pages
- load the initial catalog data from `onMounted` to avoid SSR-time fetches

## Testing
- npm run dev -- --host 0.0.0.0 --port 3000

------
https://chatgpt.com/codex/tasks/task_e_68d931b9f61c83208433b7a3ff2dc31f