### PR TITLE
Improve header dropdown handling

### DIFF
--- a/components/layout/Header.vue
+++ b/components/layout/Header.vue
@@ -126,10 +126,10 @@
             <img src="/img/products-2.jpg" alt="Profile" class="w-10 h-10 rounded-full" />
           </div>
           <ul v-if="isDropdownOpen" class="absolute right-0 mt-2 w-48 bg-white border border-gray-200 rounded-md shadow-lg">
-            <li class="px-4 py-2 hover:bg-gray-100"><NuxtLink :to="`/user/${store.currentUser.id}`">Мой профиль</NuxtLink></li>
-            <li class="px-4 py-2 hover:bg-gray-100"><NuxtLink to="/history">История бронирований</NuxtLink></li>
-            <li class="px-4 py-2 hover:bg-gray-100"><NuxtLink to="/favorites">Избранные книги</NuxtLink></li>
-            <li class="px-4 py-2 text-red-500 hover:bg-gray-100"><button @click="store.logout()">Выйти</button></li>
+            <li class="px-4 py-2 hover:bg-gray-100"><NuxtLink :to="`/user/${store.currentUser.id}`" @click="closeDropdown">Мой профиль</NuxtLink></li>
+            <li class="px-4 py-2 hover:bg-gray-100"><NuxtLink to="/history" @click="closeDropdown">История бронирований</NuxtLink></li>
+            <li class="px-4 py-2 hover:bg-gray-100"><NuxtLink to="/favorites" @click="closeDropdown">Избранные книги</NuxtLink></li>
+            <li class="px-4 py-2 text-red-500 hover:bg-gray-100"><button @click="handleLogout">Выйти</button></li>
           </ul>
         </div>
       </template>
@@ -185,5 +185,12 @@ function goToRandomMobile() {
 }
 const toggleDropdown = () => {
   isDropdownOpen.value = !isDropdownOpen.value;
+};
+const closeDropdown = () => {
+  isDropdownOpen.value = false;
+};
+const handleLogout = () => {
+  store.logout();
+  closeDropdown();
 };
 </script>


### PR DESCRIPTION
## Summary
- add a helper to close the profile dropdown menu
- close the dropdown after navigating via profile links or logging out

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d93800c24c8320982f6f16ab3e627d