### PR TITLE
Fix genre selection in book edit form

### DIFF
--- a/pages/books/[id]/edit.vue
+++ b/pages/books/[id]/edit.vue
@@ -36,10 +36,17 @@ const applyBookToForm = (book: Record<string, any>) => {
   form.isbn = book?.isbn ?? '';
   form.language = book?.language ?? '';
   form.count = Number(book?.count ?? 0);
-  form.genre_id = book?.genre_id ?? book?.genre?.id ?? '';
+  let genreId: string | number | undefined = book?.genre_id ?? book?.genre?.id;
+
+  if (!genreId && typeof book?.genre === 'string') {
+    const matchedGenre = bookStore.genres.find((genre: any) => genre?.name === book.genre);
+    genreId = matchedGenre?.id;
+  }
+
+  form.genre_id = genreId ?? '';
 };
 
-watch(() => bookStore.book, (book: any) => {
+watch(() => [bookStore.book, bookStore.genres], ([book]) => {
   if (book && Object.keys(book).length) {
     applyBookToForm(book);
   }


### PR DESCRIPTION
## Summary
- map string-based genre values from loaded books to the appropriate genre id in the edit form
- re-run book-to-form synchronization whenever book details or genre options change

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e10b9c23fc8320bc6979caa03ebc17