### PR TITLE
Track book views when opening detail page

### DIFF
--- a/pages/books/[id]/index.vue
+++ b/pages/books/[id]/index.vue
@@ -6,7 +6,7 @@ import {fetchBookById} from "~/composables/useBook";
 import {useCommentsStore} from "~/stores/comments";
 const book = ref(null);
 const route = useRoute(); // Получаем объект маршрута
-const id = ref(route.params.id); // Извлекаем ID из параметров маршрута
+const id = ref(Number(route.params.id)); // Извлекаем ID из параметров маршрута
 const store = useBookStore();
 const favoriteStore = useFavoriteStore();
 const commentStore = useCommentsStore();
@@ -19,10 +19,22 @@ const favorited = async(id: number) => {
     isFavorite.value = false
   }
 }
-onMounted(() => {
-  store.getBook(id.value)
-  store.getComments(id.value)
-  favorited(id.value)
+onMounted(async () => {
+  const bookId = Number(id.value);
+  if (Number.isNaN(bookId)) {
+    console.error('Invalid book id', id.value);
+    return;
+  }
+  store.getBook(bookId)
+  store.getComments(bookId)
+  favorited(bookId)
+  if (process.client) {
+    try {
+      await store.viewBook(bookId)
+    } catch (error) {
+      console.error('Failed to track book view', error)
+    }
+  }
 });
 const submitReview = async(content: string, book_id: number)=>{
   try{

--- a/stores/book.ts
+++ b/stores/book.ts
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia';
+import { useRuntimeConfig } from '#imports';
 import { useGlobalStore } from '~/stores/global';
 
 
@@ -62,6 +63,24 @@ export const useBookStore = defineStore('books', {
                 console.log(`book`, this.book)
             }catch (error){
                 console.log(error)
+            }
+        },
+        async viewBook(id: number) {
+            try {
+                const config = useRuntimeConfig();
+                const baseURL = config.public?.apiBase ?? 'http://127.0.0.1:8000';
+                await fetch(`${baseURL}/api/view-book/`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        accept: 'application/json'
+                    },
+                    body: JSON.stringify({
+                        book_id: id
+                    })
+                });
+            } catch (error) {
+                console.error('Failed to track book view', error);
             }
         },
         async updateBook(id: number, payload: Record<string, any>) {


### PR DESCRIPTION
## Summary
- add a Pinia action for posting book view tracking data using the configured API base URL
- invoke the tracking action from the book detail page once the book id is resolved, while guarding for client-side execution and errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e12d4042e88320933d579254fa9b11