### PR TITLE
Add authorization handling to viewBook action

### DIFF
--- a/stores/book.ts
+++ b/stores/book.ts
@@ -69,12 +69,24 @@ export const useBookStore = defineStore('books', {
             try {
                 const config = useRuntimeConfig();
                 const baseURL = config.public?.apiBase ?? 'http://127.0.0.1:8000';
+                const globalStore = useGlobalStore();
+
+                if (!globalStore.token) {
+                    return;
+                }
+
+                const headers: Record<string, string> = {
+                    'Content-Type': 'application/json',
+                    accept: 'application/json'
+                };
+
+                if (globalStore.token) {
+                    headers.Authorization = `Bearer ${globalStore.token}`;
+                }
+
                 await fetch(`${baseURL}/api/view-book/`, {
                     method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        accept: 'application/json'
-                    },
+                    headers,
                     body: JSON.stringify({
                         book_id: id
                     })


### PR DESCRIPTION
## Summary
- ensure the viewBook action reads the global store for an auth token
- skip the tracking request when unauthenticated and include the bearer header when present

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e13167dda483208253dffd70121590