### PR TITLE
Improve books grid responsiveness

### DIFF
--- a/assets/scss/global.scss
+++ b/assets/scss/global.scss
@@ -40,13 +40,39 @@ ul{
 }
 .books {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  gap: 40px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
   align-self: center;
   align-items: center;
   align-content: center;
   justify-self: center;
   text-align: center;
+}
+
+@media (min-width: 640px) {
+  .books {
+    grid-template-columns: repeat(2, minmax(180px, 1fr));
+    gap: 24px;
+  }
+}
+
+@media (min-width: 768px) {
+  .books {
+    grid-template-columns: repeat(3, minmax(200px, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .books {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 32px;
+  }
+}
+
+@media (min-width: 1280px) {
+  .books {
+    grid-template-columns: repeat(5, minmax(220px, 1fr));
+  }
 }
 
 .button-container {


### PR DESCRIPTION
## Summary
- update the global `.books` grid to use an auto-fit single-column baseline with tighter mobile spacing
- add breakpoint-specific column counts to present 2–5 cards across tablet and desktop widths

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1460fa2308320aadcfc2a9e48c9ed