### PR TITLE
Improve catalog catalog grid responsiveness

### DIFF
--- a/pages/catalog.vue
+++ b/pages/catalog.vue
@@ -132,8 +132,29 @@ onMounted(async () => {
 
 .books {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+@media (min-width: 640px) {
+  .books {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 16px;
+  }
+}
+
+@media (min-width: 768px) {
+  .books {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 20px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .books {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 24px;
+  }
 }
 
 .pagination {


### PR DESCRIPTION
## Summary
- update the catalog book grid to use auto-fit columns with a mobile-friendly gap
- add responsive breakpoints to expand the number of cards shown on tablets and desktops

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68e148a3d4388320bf66eef117091123