### PR TITLE
Improve About page responsive typography

### DIFF
--- a/components/animation/AboutItem.vue
+++ b/components/animation/AboutItem.vue
@@ -26,10 +26,12 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  margin-bottom: 40px;
+  gap: clamp(1.25rem, 3vw, 2rem);
+  margin-bottom: clamp(2rem, 5vw, 3.5rem);
   .list{
-    font-size: 24px;
-    margin-bottom: 20px;
+    font-size: clamp(1rem, 2.5vw, 1.5rem);
+    margin-bottom: clamp(1rem, 2.5vw, 1.75rem);
+    line-height: 1.6;
   }
 }
 </style>

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -139,20 +139,21 @@ const onImageLoad = () => {
 
 <style scoped>
 h1{
-  font-size: 44px;
+  font-size: clamp(2rem, 4vw + 1rem, 2.75rem);
   text-transform: uppercase;
   text-align: center;
-  margin-bottom: 80px;
+  margin-bottom: clamp(2.5rem, 6vw, 5rem);
 }
 .block1{
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 50px;
+  gap: clamp(1.75rem, 5vw, 3.125rem);
   p{
-    font-size: 30px;
+    font-size: clamp(1.125rem, 3.5vw, 1.875rem);
     text-align: center;
+    line-height: 1.6;
   }
   img{
     max-width: 100%;
@@ -160,20 +161,21 @@ h1{
   }
 }
 .block2{
-  margin-top: 80px;
+  margin-top: clamp(3rem, 7vw, 5rem);
   .block2__title{
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 20px;
-    margin-bottom: 40px;
+    gap: clamp(1.25rem, 3vw, 2rem);
+    margin-bottom: clamp(2rem, 5vw, 3.5rem);
     h2{
-      font-size: 40px;
+      font-size: clamp(1.75rem, 3.5vw, 2.5rem);
     }
     p{
-      font-size: 24px;
+      font-size: clamp(1.0625rem, 2.8vw, 1.5rem);
       text-align: center;
+      line-height: 1.7;
     }
     .history{
       width: 80vw;


### PR DESCRIPTION
## Summary
- update About page headings and paragraphs to use clamp-based sizing for better readability across breakpoints
- tune spacing within the hero and section headers to maintain comfortable density after font adjustments
- scale list typography inside AboutItem so items stay compact on mobile and grow on larger screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e14d901d948320929476ea8b73c876