### PR TITLE
Improve quotes section responsive typography

### DIFF
--- a/components/quotes/Quote.vue
+++ b/components/quotes/Quote.vue
@@ -29,7 +29,7 @@ onMounted(async () => {
 
 <template>
 <div class="item" ref="containerRef">
-  <h2 class="text-1xl">{{title}}</h2>
+  <h2>{{title}}</h2>
   <p ref="textRef">{{text}}</p>
   <span>{{author}}</span>
 </div>
@@ -51,19 +51,19 @@ onMounted(async () => {
         /* Глубокая тень для объёмности */
 
     h2{
-      font-size: 18px !important;
+      font-size: clamp(1.125rem, 2.2vw, 1.5rem);
       font-weight: 700;
       text-align: center;
     }
     p{
-      font-size: 16px !important;
+      font-size: clamp(1rem, 2vw, 1.25rem);
       text-align: center;
       overflow-wrap: break-word;
       flex-grow: 1;
     }
     span{
       font-style: italic;
-      font-size: 12px;
+      font-size: clamp(0.875rem, 1.8vw, 1rem);
       text-align: end;
     }
   }

--- a/components/quotes/Quotes.vue
+++ b/components/quotes/Quotes.vue
@@ -98,7 +98,7 @@ onMounted(()=>{
 
 <template>
   <div class="quotes main">
-    <h1 class="text-4xl font-bold">Цитаты</h1>
+    <h1 class="text-2xl font-bold sm:text-3xl lg:text-4xl">Цитаты</h1>
     <ClientOnly>
       <swiper-container ref="containerRef" :init="false">
         <swiper-slide


### PR DESCRIPTION
## Summary
- adjust the quotes page heading to use responsive Tailwind text sizing
- refresh quote card typography with clamp-based font sizes that still work with fitText

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e14ffd77d08320aea0a5deb62c8e3f