### PR TITLE
Align book grid cards to uniform height

### DIFF
--- a/assets/scss/global.scss
+++ b/assets/scss/global.scss
@@ -43,10 +43,17 @@ ul{
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 16px;
   align-self: center;
-  align-items: center;
-  align-content: center;
+  align-items: stretch;
+  align-content: stretch;
+  justify-items: stretch;
+  grid-auto-rows: 1fr;
   justify-self: center;
   text-align: center;
+}
+
+.books > * {
+  display: flex;
+  height: 100%;
 }
 
 @media (min-width: 640px) {

--- a/pages/catalog.vue
+++ b/pages/catalog.vue
@@ -134,6 +134,10 @@ onMounted(async () => {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 12px;
+  align-items: stretch;
+  align-content: stretch;
+  justify-items: stretch;
+  grid-auto-rows: 1fr;
 }
 
 @media (min-width: 640px) {

--- a/pages/recomendation.vue
+++ b/pages/recomendation.vue
@@ -68,5 +68,9 @@ onMounted(fetchBooks)
   display: grid;
   grid-template-columns: repeat(5, 1fr);
   gap: 20px;
+  align-items: stretch;
+  align-content: stretch;
+  justify-items: stretch;
+  grid-auto-rows: 1fr;
 }
 </style>


### PR DESCRIPTION
## Summary
- stretch book grid tracks to a consistent height and ensure children can fill the cell
- update catalog and recommendation scoped styles so they inherit the new stretch behavior

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e23a69864c8320bcf1639a4f4a8e7d