### PR TITLE
Allow force closing of admin book dialogs

### DIFF
--- a/pages/admin/books/create.vue
+++ b/pages/admin/books/create.vue
@@ -159,8 +159,8 @@ const openNewTagDialog = () => {
   showNewTagDialog.value = true;
 };
 
-const closeNewGenreDialog = () => {
-  if (creatingGenre.value) {
+const closeNewGenreDialog = (force = false) => {
+  if (creatingGenre.value && !force) {
     return;
   }
   showNewGenreDialog.value = false;
@@ -168,8 +168,8 @@ const closeNewGenreDialog = () => {
   newGenreError.value = '';
 };
 
-const closeNewTagDialog = () => {
-  if (creatingTag.value) {
+const closeNewTagDialog = (force = false) => {
+  if (creatingTag.value && !force) {
     return;
   }
   showNewTagDialog.value = false;
@@ -214,7 +214,7 @@ const handleCreateGenre = async () => {
       form.genre_id = createdGenre.id;
     }
 
-    closeNewGenreDialog();
+    closeNewGenreDialog(true);
   } catch (error: any) {
     console.error(error);
     newGenreError.value = error?.message || 'Не удалось создать жанр';
@@ -264,7 +264,7 @@ const handleCreateTag = async () => {
       }
     }
 
-    closeNewTagDialog();
+    closeNewTagDialog(true);
   } catch (error: any) {
     console.error(error);
     newTagError.value = error?.message || 'Не удалось создать тег';


### PR DESCRIPTION
## Summary
- allow programmatic closing of the new genre/tag dialogs while requests are in flight
- close the dialogs immediately after successful genre/tag creation requests

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e25a29c0f48320955991ab34901494