### PR TITLE
feat: add genre and tag management dialogs on admin book create

### DIFF
--- a/pages/admin/books/create.vue
+++ b/pages/admin/books/create.vue
@@ -29,12 +29,26 @@ const form = reactive({
 
 const showNewGenreDialog = ref(false);
 const showNewTagDialog = ref(false);
+const showEditGenreDialog = ref(false);
+const showDeleteGenreDialog = ref(false);
+const showEditTagDialog = ref(false);
+const showDeleteTagDialog = ref(false);
 const newGenreName = ref('');
 const newTagName = ref('');
 const newGenreError = ref('');
 const newTagError = ref('');
+const genreActionError = ref('');
+const tagActionError = ref('');
 const creatingGenre = ref(false);
 const creatingTag = ref(false);
+const updatingGenre = ref(false);
+const deletingGenre = ref(false);
+const updatingTag = ref(false);
+const deletingTag = ref(false);
+const editingGenre = ref<any | null>(null);
+const editingTag = ref<any | null>(null);
+const genreFormName = ref('');
+const tagFormName = ref('');
 
 const tags = computed(() => Array.isArray(bookStore.tags) ? bookStore.tags : []);
 const genres = computed(() => Array.isArray(bookStore.genres) ? bookStore.genres : []);
@@ -153,10 +167,86 @@ const openNewGenreDialog = () => {
   showNewGenreDialog.value = true;
 };
 
+const openEditGenreDialog = (genreId: string | number | undefined) => {
+  if (!genreId) {
+    return;
+  }
+
+  const genre = genres.value.find((item: any) => String(item.id) === String(genreId));
+  if (!genre) {
+    return;
+  }
+
+  editingGenre.value = genre;
+  genreFormName.value = genre?.name ?? '';
+  genreActionError.value = '';
+  showEditGenreDialog.value = true;
+};
+
+const openDeleteGenreDialog = (genreId: string | number | undefined) => {
+  if (!genreId) {
+    return;
+  }
+
+  const genre = genres.value.find((item: any) => String(item.id) === String(genreId));
+  if (!genre) {
+    return;
+  }
+
+  editingGenre.value = genre;
+  genreActionError.value = '';
+  showDeleteGenreDialog.value = true;
+};
+
 const openNewTagDialog = () => {
   newTagName.value = '';
   newTagError.value = '';
   showNewTagDialog.value = true;
+};
+
+const openEditTagDialog = (tag: any) => {
+  if (!tag) {
+    return;
+  }
+
+  editingTag.value = tag;
+  tagFormName.value = tag?.name ?? '';
+  tagActionError.value = '';
+  showEditTagDialog.value = true;
+};
+
+const openDeleteTagDialog = (tag: any) => {
+  if (!tag) {
+    return;
+  }
+
+  editingTag.value = tag;
+  tagActionError.value = '';
+  showDeleteTagDialog.value = true;
+};
+
+const openDefaultTagEditDialog = () => {
+  const preferredId = form.tag_ids[0] ?? tags.value[0]?.id;
+  if (!preferredId) {
+    return;
+  }
+
+  const tag = tags.value.find((item: any) => String(item.id) === String(preferredId));
+  if (tag) {
+    openEditTagDialog(tag);
+  }
+};
+
+const openDefaultTagDeleteDialog = () => {
+  const preferredId = form.tag_ids[0] ?? tags.value[0]?.id;
+  if (!preferredId) {
+    return;
+  }
+
+  const tag = tags.value.find((item: any) => String(item.id) === String(preferredId));
+  if (tag) {
+    openDeleteTagDialog(tag);
+  }
 };
 
 const closeNewGenreDialog = () => {
@@ -168,6 +258,25 @@ const closeNewGenreDialog = () => {
   newGenreError.value = '';
 };
 
+const closeEditGenreDialog = () => {
+  if (updatingGenre.value) {
+    return;
+  }
+  showEditGenreDialog.value = false;
+  genreFormName.value = '';
+  genreActionError.value = '';
+  editingGenre.value = null;
+};
+
+const closeDeleteGenreDialog = () => {
+  if (deletingGenre.value) {
+    return;
+  }
+  showDeleteGenreDialog.value = false;
+  genreActionError.value = '';
+  editingGenre.value = null;
+};
+
 const closeNewTagDialog = () => {
   if (creatingTag.value) {
     return;
@@ -175,6 +284,25 @@ const closeNewTagDialog = () => {
   showNewTagDialog.value = false;
   newTagName.value = '';
   newTagError.value = '';
+};
+
+const closeEditTagDialog = () => {
+  if (updatingTag.value) {
+    return;
+  }
+  showEditTagDialog.value = false;
+  tagFormName.value = '';
+  tagActionError.value = '';
+  editingTag.value = null;
+};
+
+const closeDeleteTagDialog = () => {
+  if (deletingTag.value) {
+    return;
+  }
+  showDeleteTagDialog.value = false;
+  tagActionError.value = '';
+  editingTag.value = null;
 };
 
 const handleCreateGenre = async () => {
@@ -220,6 +348,20 @@ const handleCreateGenre = async () => {
     newGenreError.value = error?.message || 'Не удалось создать жанр';
   } finally {
     creatingGenre.value = false;
+  }
+};
+
+const synchronizeSelectedGenre = (genreId: string | number | undefined) => {
+  if (!genreId) {
+    form.genre_id = '';
+    return;
+  }
+
+  const exists = genres.value.some((genre: any) => String(genre.id) === String(genreId));
+  if (!exists) {
+    form.genre_id = '';
+  } else {
+    form.genre_id = genreId;
   }
 };
 
@@ -273,6 +415,197 @@ const handleCreateTag = async () => {
   }
 };
 
+const synchronizeSelectedTags = (tagIds: Array<string | number>) => {
+  const availableIds = new Set(tags.value.map((tag: any) => String(tag.id)));
+  form.tag_ids = tagIds
+    .map((id) => (typeof id === 'number' || typeof id === 'string' ? id : String(id)))
+    .filter((id) => availableIds.has(String(id)));
+};
+
+const handleUpdateGenre = async () => {
+  if (!editingGenre.value) {
+    return;
+  }
+
+  if (!genreFormName.value.trim()) {
+    genreActionError.value = 'Введите название жанра';
+    return;
+  }
+
+  if (!globalStore.token) {
+    genreActionError.value = 'Требуется авторизация для обновления жанра';
+    return;
+  }
+
+  updatingGenre.value = true;
+  genreActionError.value = '';
+
+  const genreId = editingGenre.value.id;
+
+  try {
+    const response = await fetch(`http://127.0.0.1:8000/api/genres/${genreId}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${globalStore.token}`,
+        accept: 'application/json'
+      },
+      body: JSON.stringify({ name: genreFormName.value.trim() })
+    });
+
+    const responseData = response.status === 204 ? {} : await response.json().catch(() => ({}));
+    if (!response.ok) {
+      throw new Error((responseData as any)?.message || 'Не удалось обновить жанр');
+    }
+
+    const previousGenreId = editingGenre.value.id;
+    await bookStore.get_categories();
+    synchronizeSelectedGenre(previousGenreId);
+    closeEditGenreDialog();
+  } catch (error: any) {
+    console.error(error);
+    genreActionError.value = error?.message || 'Не удалось обновить жанр';
+  } finally {
+    updatingGenre.value = false;
+  }
+};
+
+const handleDeleteGenre = async () => {
+  if (!editingGenre.value) {
+    return;
+  }
+
+  if (!globalStore.token) {
+    genreActionError.value = 'Требуется авторизация для удаления жанра';
+    return;
+  }
+
+  deletingGenre.value = true;
+  genreActionError.value = '';
+
+  const genreId = editingGenre.value.id;
+
+  try {
+    const response = await fetch(`http://127.0.0.1:8000/api/genres/${genreId}`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${globalStore.token}`,
+        accept: 'application/json'
+      }
+    });
+
+    if (!response.ok) {
+      const responseData = response.status === 204 ? {} : await response.json().catch(() => ({}));
+      throw new Error((responseData as any)?.message || 'Не удалось удалить жанр');
+    }
+
+    const deletedGenreId = editingGenre.value.id;
+    await bookStore.get_categories();
+
+    if (String(form.genre_id) === String(deletedGenreId)) {
+      form.genre_id = '';
+    } else {
+      synchronizeSelectedGenre(form.genre_id);
+    }
+
+    closeDeleteGenreDialog();
+  } catch (error: any) {
+    console.error(error);
+    genreActionError.value = error?.message || 'Не удалось удалить жанр';
+  } finally {
+    deletingGenre.value = false;
+  }
+};
+
+const handleUpdateTag = async () => {
+  if (!editingTag.value) {
+    return;
+  }
+
+  if (!tagFormName.value.trim()) {
+    tagActionError.value = 'Введите название тега';
+    return;
+  }
+
+  if (!globalStore.token) {
+    tagActionError.value = 'Требуется авторизация для обновления тега';
+    return;
+  }
+
+  updatingTag.value = true;
+  tagActionError.value = '';
+
+  const tagId = editingTag.value.id;
+
+  try {
+    const response = await fetch(`http://127.0.0.1:8000/api/tags/${tagId}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${globalStore.token}`,
+        accept: 'application/json'
+      },
+      body: JSON.stringify({ name: tagFormName.value.trim() })
+    });
+
+    const responseData = response.status === 204 ? {} : await response.json().catch(() => ({}));
+    if (!response.ok) {
+      throw new Error((responseData as any)?.message || 'Не удалось обновить тег');
+    }
+
+    const previousSelectedTags = [...form.tag_ids];
+    await fetchTags();
+    synchronizeSelectedTags(previousSelectedTags);
+    closeEditTagDialog();
+  } catch (error: any) {
+    console.error(error);
+    tagActionError.value = error?.message || 'Не удалось обновить тег';
+  } finally {
+    updatingTag.value = false;
+  }
+};
+
+const handleDeleteTag = async () => {
+  if (!editingTag.value) {
+    return;
+  }
+
+  if (!globalStore.token) {
+    tagActionError.value = 'Требуется авторизация для удаления тега';
+    return;
+  }
+
+  deletingTag.value = true;
+  tagActionError.value = '';
+
+  const tagId = editingTag.value.id;
+
+  try {
+    const response = await fetch(`http://127.0.0.1:8000/api/tags/${tagId}`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${globalStore.token}`,
+        accept: 'application/json'
+      }
+    });
+
+    if (!response.ok) {
+      const responseData = response.status === 204 ? {} : await response.json().catch(() => ({}));
+      throw new Error((responseData as any)?.message || 'Не удалось удалить тег');
+    }
+
+    const previousSelectedTags = form.tag_ids.filter((id) => String(id) !== String(tagId));
+    await fetchTags();
+    synchronizeSelectedTags(previousSelectedTags);
+    closeDeleteTagDialog();
+  } catch (error: any) {
+    console.error(error);
+    tagActionError.value = error?.message || 'Не удалось удалить тег';
+  } finally {
+    deletingTag.value = false;
+  }
+};
+
 onMounted(() => {
   loadInitialData();
 });
@@ -312,15 +645,33 @@ onMounted(() => {
         </div>
 
         <div>
-          <div class="flex items-center justify-between mb-1">
+          <div class="flex flex-wrap items-center justify-between gap-2 mb-1">
             <label class="block text-sm font-medium text-gray-700" for="genre">Жанр</label>
-            <button
-              type="button"
-              class="text-sm text-indigo-600 hover:text-indigo-700"
-              @click="openNewGenreDialog"
-            >
-              Добавить новый жанр
-            </button>
+            <div class="flex flex-wrap items-center gap-3 text-sm">
+              <button
+                type="button"
+                class="text-indigo-600 hover:text-indigo-700"
+                @click="openNewGenreDialog"
+              >
+                Добавить
+              </button>
+              <button
+                type="button"
+                class="text-indigo-600 hover:text-indigo-700 disabled:text-gray-400"
+                :disabled="!genres.length"
+                @click="openEditGenreDialog(form.genre_id || genres[0]?.id)"
+              >
+                Редактировать
+              </button>
+              <button
+                type="button"
+                class="text-red-600 hover:text-red-700 disabled:text-gray-400"
+                :disabled="!genres.length"
+                @click="openDeleteGenreDialog(form.genre_id || genres[0]?.id)"
+              >
+                Удалить
+              </button>
+            </div>
           </div>
           <select
             id="genre"
@@ -337,18 +688,62 @@ onMounted(() => {
               {{ genre.name }}
             </option>
           </select>
+          <div v-if="genres.length" class="mt-3 space-y-2 rounded-md border border-gray-200 p-3">
+            <p class="text-xs uppercase tracking-wide text-gray-500">Список жанров</p>
+            <div
+              v-for="genre in genres"
+              :key="`genre-${genre.id}`"
+              class="flex items-center justify-between rounded-md border border-gray-100 bg-gray-50 px-3 py-2"
+            >
+              <span class="text-sm text-gray-700">{{ genre.name }}</span>
+              <div class="flex items-center gap-2 text-xs">
+                <button
+                  type="button"
+                  class="text-indigo-600 hover:text-indigo-700"
+                  @click="openEditGenreDialog(genre.id)"
+                >
+                  Редактировать
+                </button>
+                <button
+                  type="button"
+                  class="text-red-600 hover:text-red-700"
+                  @click="openDeleteGenreDialog(genre.id)"
+                >
+                  Удалить
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
 
         <div>
-          <div class="flex items-center justify-between mb-1">
+          <div class="flex flex-wrap items-center justify-between gap-2 mb-1">
             <label class="block text-sm font-medium text-gray-700" for="tags">Теги</label>
-            <button
-              type="button"
-              class="text-sm text-indigo-600 hover:text-indigo-700"
-              @click="openNewTagDialog"
-            >
-              Добавить новый тег
-            </button>
+            <div class="flex flex-wrap items-center gap-3 text-sm">
+              <button
+                type="button"
+                class="text-indigo-600 hover:text-indigo-700"
+                @click="openNewTagDialog"
+              >
+                Добавить
+              </button>
+              <button
+                type="button"
+                class="text-indigo-600 hover:text-indigo-700 disabled:text-gray-400"
+                :disabled="!tags.length"
+                @click="openDefaultTagEditDialog"
+              >
+                Редактировать
+              </button>
+              <button
+                type="button"
+                class="text-red-600 hover:text-red-700 disabled:text-gray-400"
+                :disabled="!tags.length"
+                @click="openDefaultTagDeleteDialog"
+              >
+                Удалить
+              </button>
+            </div>
           </div>
           <select
             id="tags"
@@ -365,6 +760,32 @@ onMounted(() => {
             </option>
           </select>
           <p class="mt-1 text-sm text-gray-500">Используйте Ctrl/Cmd для выбора нескольких тегов.</p>
+          <div v-if="tags.length" class="mt-3 space-y-2 rounded-md border border-gray-200 p-3">
+            <p class="text-xs uppercase tracking-wide text-gray-500">Список тегов</p>
+            <div
+              v-for="tag in tags"
+              :key="`tag-${tag.id}`"
+              class="flex items-center justify-between rounded-md border border-gray-100 bg-gray-50 px-3 py-2"
+            >
+              <span class="text-sm text-gray-700">{{ tag.name }}</span>
+              <div class="flex items-center gap-2 text-xs">
+                <button
+                  type="button"
+                  class="text-indigo-600 hover:text-indigo-700"
+                  @click="openEditTagDialog(tag)"
+                >
+                  Редактировать
+                </button>
+                <button
+                  type="button"
+                  class="text-red-600 hover:text-red-700"
+                  @click="openDeleteTagDialog(tag)"
+                >
+                  Удалить
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
 
         <div>
@@ -484,6 +905,72 @@ onMounted(() => {
     </div>
 
     <div
+      v-if="showEditGenreDialog"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+    >
+      <div class="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+        <h2 class="text-lg font-semibold text-gray-900">Редактирование жанра</h2>
+        <p class="mt-1 text-sm text-gray-500">Измените название выбранного жанра.</p>
+        <input
+          v-model="genreFormName"
+          type="text"
+          class="mt-4 w-full rounded-md border border-gray-300 px-4 py-2 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+          placeholder="Название жанра"
+        />
+        <p v-if="genreActionError" class="mt-2 text-sm text-red-600">{{ genreActionError }}</p>
+        <div class="mt-6 flex justify-end gap-3">
+          <button
+            type="button"
+            class="rounded-full border border-gray-300 px-4 py-2 text-gray-700 hover:bg-gray-50"
+            @click="closeEditGenreDialog"
+            :disabled="updatingGenre"
+          >
+            Отмена
+          </button>
+          <button
+            type="button"
+            :disabled="updatingGenre"
+            class="rounded-full bg-indigo-600 px-4 py-2 text-white hover:bg-indigo-700 disabled:opacity-70"
+            @click="handleUpdateGenre"
+          >
+            {{ updatingGenre ? 'Сохранение...' : 'Сохранить' }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div
+      v-if="showDeleteGenreDialog"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+    >
+      <div class="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+        <h2 class="text-lg font-semibold text-gray-900">Удалить жанр</h2>
+        <p class="mt-1 text-sm text-gray-500">
+          Вы уверены, что хотите удалить жанр «{{ editingGenre?.name }}»? Это действие нельзя отменить.
+        </p>
+        <p v-if="genreActionError" class="mt-2 text-sm text-red-600">{{ genreActionError }}</p>
+        <div class="mt-6 flex justify-end gap-3">
+          <button
+            type="button"
+            class="rounded-full border border-gray-300 px-4 py-2 text-gray-700 hover:bg-gray-50"
+            @click="closeDeleteGenreDialog"
+            :disabled="deletingGenre"
+          >
+            Отмена
+          </button>
+          <button
+            type="button"
+            :disabled="deletingGenre"
+            class="rounded-full bg-red-600 px-4 py-2 text-white hover:bg-red-700 disabled:opacity-70"
+            @click="handleDeleteGenre"
+          >
+            {{ deletingGenre ? 'Удаление...' : 'Удалить' }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div
       v-if="showNewTagDialog"
       class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
     >
@@ -512,6 +999,72 @@ onMounted(() => {
             @click="handleCreateTag"
           >
             {{ creatingTag ? 'Создание...' : 'Создать' }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div
+      v-if="showEditTagDialog"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+    >
+      <div class="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+        <h2 class="text-lg font-semibold text-gray-900">Редактирование тега</h2>
+        <p class="mt-1 text-sm text-gray-500">Измените название выбранного тега.</p>
+        <input
+          v-model="tagFormName"
+          type="text"
+          class="mt-4 w-full rounded-md border border-gray-300 px-4 py-2 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+          placeholder="Название тега"
+        />
+        <p v-if="tagActionError" class="mt-2 text-sm text-red-600">{{ tagActionError }}</p>
+        <div class="mt-6 flex justify-end gap-3">
+          <button
+            type="button"
+            class="rounded-full border border-gray-300 px-4 py-2 text-gray-700 hover:bg-gray-50"
+            @click="closeEditTagDialog"
+            :disabled="updatingTag"
+          >
+            Отмена
+          </button>
+          <button
+            type="button"
+            :disabled="updatingTag"
+            class="rounded-full bg-indigo-600 px-4 py-2 text-white hover:bg-indigo-700 disabled:opacity-70"
+            @click="handleUpdateTag"
+          >
+            {{ updatingTag ? 'Сохранение...' : 'Сохранить' }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div
+      v-if="showDeleteTagDialog"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+    >
+      <div class="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+        <h2 class="text-lg font-semibold text-gray-900">Удалить тег</h2>
+        <p class="mt-1 text-sm text-gray-500">
+          Вы уверены, что хотите удалить тег «{{ editingTag?.name }}»? Это действие нельзя отменить.
+        </p>
+        <p v-if="tagActionError" class="mt-2 text-sm text-red-600">{{ tagActionError }}</p>
+        <div class="mt-6 flex justify-end gap-3">
+          <button
+            type="button"
+            class="rounded-full border border-gray-300 px-4 py-2 text-gray-700 hover:bg-gray-50"
+            @click="closeDeleteTagDialog"
+            :disabled="deletingTag"
+          >
+            Отмена
+          </button>
+          <button
+            type="button"
+            :disabled="deletingTag"
+            class="rounded-full bg-red-600 px-4 py-2 text-white hover:bg-red-700 disabled:opacity-70"
+            @click="handleDeleteTag"
+          >
+            {{ deletingTag ? 'Удаление...' : 'Удалить' }}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add reactive state and dialogs to edit or delete genres and tags from the admin book creation page
- implement API handlers that update or remove genres and tags and synchronize form selections after refresh
- expose management controls beside the genre and tag lists so administrators can launch the new dialogs

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e25a3a2a5c8320827bf0630bd5501c