### PR TITLE
Reload page after adding favorite book

### DIFF
--- a/components/books/BooksPageItem.vue
+++ b/components/books/BooksPageItem.vue
@@ -48,6 +48,9 @@ const toggleFavorite = async () => {
       await favoritesStore.removeFavorites(props.id);
     } else {
       await favoritesStore.addFavorite(props.id);
+      if (process.client) {
+        window.location.reload();
+      }
     }
   } catch (error) {
     console.error('Ошибка при обновлении избранного:', error);


### PR DESCRIPTION
## Summary
- reload the page after successfully adding a book to favorites to reflect the update immediately

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e26abc86088320936b86653e85f2e9