### PR TITLE
Update random book navigation to use full reload

### DIFF
--- a/components/layout/Header.vue
+++ b/components/layout/Header.vue
@@ -189,7 +189,11 @@ const showSearchMobile = () => {
   isSearched.value = true;
 };
 function goToRandom() {
-  router.push({ path: '/random/book', force: true });
+  if (process.client) {
+    window.location.assign('/random/book');
+  } else {
+    router.push('/random/book');
+  }
 }
 function goToRandomMobile() {
   closeMobile();


### PR DESCRIPTION
## Summary
- update the header random book handler to trigger a full client navigation when available
- reuse the same navigation logic for the mobile random book handler after closing the menu

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e26abc6ce4832093e62df26b3d208d