### PR TITLE
Handle AI recommendation response variations

### DIFF
--- a/stores/book.ts
+++ b/stores/book.ts
@@ -250,7 +250,12 @@ export const useBookStore = defineStore('books', {
                     throw new Error(responseData?.message || 'Не удалось получить рекомендации');
                 }
 
-                const recommendations = responseData?.data ?? responseData ?? [];
+                const recommendations = Array.isArray(responseData?.books)
+                    ? responseData.books
+                    : Array.isArray(responseData?.data)
+                        ? responseData.data
+                        : [];
+
                 this.aiRecommendations = Array.isArray(recommendations) ? recommendations : [];
                 return this.aiRecommendations;
             } catch (error) {


### PR DESCRIPTION
## Summary
- extract AI recommendations from `responseData.books` with a fallback to `responseData.data`
- default the stored recommendations to an empty array when the response payload is not an array

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2a9d27e2c83208ebddfe2a7927b9a