### PR TITLE
Display genre and metadata on book cards

### DIFF
--- a/components/books/Books.vue
+++ b/components/books/Books.vue
@@ -11,6 +11,27 @@ const perPage = 12;
 
 const { fetchRandomBooks } = useBooks();
 
+const resolveGenre = (book) =>
+  book?.genre?.name ||
+  book?.genre?.title ||
+  book?.genre_name ||
+  book?.genre;
+
+const resolvePublicationDate = (book) =>
+  book?.publication_date ||
+  book?.publicationDate ||
+  book?.published_at ||
+  book?.publishedAt ||
+  book?.release_date ||
+  book?.releaseDate;
+
+const resolveDescription = (book) =>
+  book?.description ||
+  book?.short_description ||
+  book?.shortDescription ||
+  book?.summary ||
+  book?.annotation;
+
 const loadInitialBooks = async () => {
   isInitialLoading.value = true;
   try {
@@ -68,6 +89,9 @@ onMounted(() => {
               :title="book.title"
               :author="book.author"
               :image-src="book.image"
+              :genre="resolveGenre(book)"
+              :publication-date="resolvePublicationDate(book)"
+              :description="resolveDescription(book)"
               :id ="book.id"
           />
         </div>

--- a/components/books/EducationBooks.vue
+++ b/components/books/EducationBooks.vue
@@ -12,6 +12,27 @@ const perPage = 12;
 
 const { fetchRandomBooks } = educationBooks();
 
+const resolveGenre = (book: Record<string, any>) =>
+  book?.genre?.name ||
+  book?.genre?.title ||
+  book?.genre_name ||
+  book?.genre;
+
+const resolvePublicationDate = (book: Record<string, any>) =>
+  book?.publication_date ||
+  book?.publicationDate ||
+  book?.published_at ||
+  book?.publishedAt ||
+  book?.release_date ||
+  book?.releaseDate;
+
+const resolveDescription = (book: Record<string, any>) =>
+  book?.description ||
+  book?.short_description ||
+  book?.shortDescription ||
+  book?.summary ||
+  book?.annotation;
+
 const loadInitialBooks = async () => {
   isInitialLoading.value = true;
   try {
@@ -69,6 +90,9 @@ onMounted(() => {
               :title="book.title"
               :author="book.author"
               :image-src="book.image"
+              :genre="resolveGenre(book)"
+              :publication-date="resolvePublicationDate(book)"
+              :description="resolveDescription(book)"
               :id ="book.id"
           />
         </div>

--- a/components/books/NewBooks.vue
+++ b/components/books/NewBooks.vue
@@ -10,6 +10,9 @@
               :title="book.title"
               :author="book.author"
               :image-src="book.image"
+              :genre="resolveGenre(book)"
+              :publication-date="resolvePublicationDate(book)"
+              :description="resolveDescription(book)"
               :id ="book.id"
           />
         </div>
@@ -36,6 +39,27 @@ const page = ref(1);
 const perPage = 12;
 
 const { fetchRandomBooks } = useNewBook();
+
+const resolveGenre = (book) =>
+  book?.genre?.name ||
+  book?.genre?.title ||
+  book?.genre_name ||
+  book?.genre;
+
+const resolvePublicationDate = (book) =>
+  book?.publication_date ||
+  book?.publicationDate ||
+  book?.published_at ||
+  book?.publishedAt ||
+  book?.release_date ||
+  book?.releaseDate;
+
+const resolveDescription = (book) =>
+  book?.description ||
+  book?.short_description ||
+  book?.shortDescription ||
+  book?.summary ||
+  book?.annotation;
 
 const loadInitialBooks = async () => {
   isInitialLoading.value = true;

--- a/pages/catalog.vue
+++ b/pages/catalog.vue
@@ -51,6 +51,9 @@
             :title="book.title"
             :author="book.author"
             :image-src="book.image"
+            :genre="resolveGenre(book)"
+            :publication-date="resolvePublicationDate(book)"
+            :description="resolveDescription(book)"
             :id ="book.id"
         />
       </div>
@@ -73,6 +76,27 @@ const selectedLanguage = ref('ru'); // Язык по умолчанию (рус�
 const loading = ref(false);
 const perPage = 40;
 const page = ref(1);
+
+const resolveGenre = (book: Record<string, any>) =>
+  book?.genre?.name ||
+  book?.genre?.title ||
+  book?.genre_name ||
+  book?.genre;
+
+const resolvePublicationDate = (book: Record<string, any>) =>
+  book?.publication_date ||
+  book?.publicationDate ||
+  book?.published_at ||
+  book?.publishedAt ||
+  book?.release_date ||
+  book?.releaseDate;
+
+const resolveDescription = (book: Record<string, any>) =>
+  book?.description ||
+  book?.short_description ||
+  book?.shortDescription ||
+  book?.summary ||
+  book?.annotation;
 
 const fetchBooksByCategory = async () => {
   loading.value = true;


### PR DESCRIPTION
## Summary
- expose helper functions in book list components to normalize genre, publication date, and description values before passing them to the card component
- update the catalog page to pass the same metadata so all book grids render the additional details when available

## Testing
- not run (API/backend services unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2ad80e3488320ae1de339487674e9