### PR TITLE
Add AI-enhanced book search flow

### DIFF
--- a/components/layout/Header.vue
+++ b/components/layout/Header.vue
@@ -175,14 +175,30 @@ const closeMobile = () => {
   mobileMenuOpen.value = false;
 };
 const onSearch = () => {
-  if (searchQuery.value.trim()) {
-    isSearched.value = false;
-    navigateTo(`/search/${encodeURIComponent(searchQuery.value.trim())}`);
-    searchQuery.value = "";
-    mobileMenuOpen.value = false;
-  } else {
+  const query = searchQuery.value.trim();
+  if (!query) {
     isSearched.value = true;
+    return;
   }
+
+  isSearched.value = false;
+  mobileMenuOpen.value = false;
+
+  if (isNpl.value) {
+    if (!store.token) {
+      console.warn('Для AI-поиска необходимо авторизоваться. Выполняем обычный поиск.');
+      navigateTo(`/search/${encodeURIComponent(query)}`);
+    } else {
+      navigateTo({
+        path: `/search/${encodeURIComponent(query)}`,
+        query: { ai: '1' }
+      });
+    }
+  } else {
+    navigateTo(`/search/${encodeURIComponent(query)}`);
+  }
+
+  searchQuery.value = "";
 };
 const showSearchMobile = () => {
   closeMobile();

--- a/stores/book.ts
+++ b/stores/book.ts
@@ -57,6 +57,41 @@ export const useBookStore = defineStore('books', {
                 console.log(error);
             }
         },
+        async searchBooksAi(text: string) {
+            const trimmedText = text?.trim();
+            if (!trimmedText) {
+                this.searched_books = [];
+                return;
+            }
+
+            try {
+                const config = useRuntimeConfig();
+                const baseURL = config.public?.apiBase ?? 'http://127.0.0.1:8000';
+                const globalStore = useGlobalStore();
+
+                if (!globalStore.token) {
+                    console.warn('AI поиск доступен только авторизованным пользователям');
+                    this.searched_books = [];
+                    return;
+                }
+
+                const params = new URLSearchParams({
+                    text: trimmedText,
+                    token: globalStore.token
+                });
+
+                const response = await fetch(`${baseURL}/npl/suggest-tags?${params.toString()}`, {
+                    headers: {
+                        accept: 'application/json'
+                    }
+                });
+                const data = await response.json();
+                this.searched_books = Array.isArray(data.books) ? data.books : [];
+            } catch (error) {
+                console.error('AI search failed', error);
+                this.searched_books = [];
+            }
+        },
         async getBook(id: number){
             try {
                 const response = await fetch(`http://127.0.0.1:8000/api/books/${id}`)


### PR DESCRIPTION
## Summary
- add an AI-powered search action in the book store that calls the suggest-tags endpoint with the user token
- update the header search control to route AI searches with a query flag when the user is authenticated
- adjust the search results page to choose between AI and standard searches and react to route changes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2bfb6e930832098f171dc036e8f9a