### PR TITLE
Fix auth logo placement

### DIFF
--- a/pages/auth/login.vue
+++ b/pages/auth/login.vue
@@ -31,6 +31,7 @@ const onLogin = async () => {
 
 <template>
   <div class="form__block">
+    <span class="logo">LibraryApp</span>
     <form action="" class="form" @submit.prevent>
       <div class="input__block">
         <label for="email">Ваша почта</label>
@@ -44,7 +45,6 @@ const onLogin = async () => {
       <button type="button" class="btn" @click="onLogin">Войти</button>
       <NuxtLink style="text-align: center" to="/auth/register">Зарегистрироваться</NuxtLink>
     </form>
-    <span class="logo">LibraryApp</span>
   </div>
 </template>
 
@@ -108,6 +108,7 @@ const onLogin = async () => {
     font-size: clamp(32px, 10vw, 40px);
     font-weight: 600;
     letter-spacing: 2px;
+    text-align: center;
   }
 }
 
@@ -134,11 +135,7 @@ const onLogin = async () => {
   }
 
   .logo {
-    position: absolute;
-    right: -70px;
-    top: 50%;
-    transform: translateY(-50%);
-    rotate: -90deg;
+    text-align: center;
   }
 }
 </style>

--- a/pages/auth/register.vue
+++ b/pages/auth/register.vue
@@ -54,6 +54,7 @@ const onRegistr = async () => {
 
 <template>
   <div class="form__block">
+    <span class="logo">LibraryApp</span>
     <form action="" class="form">
       <div class="input__block">
         <label for="name">
@@ -85,7 +86,6 @@ const onRegistr = async () => {
       <button type="button" class="btn" @click="onRegistr">Зарегистрироваться</button>
       <NuxtLink style="text-align: center" to="/auth/login">Войти</NuxtLink>
     </form>
-    <span class="logo">LibraryApp</span>
   </div>
 </template>
 
@@ -149,6 +149,7 @@ const onRegistr = async () => {
     font-size: clamp(32px, 10vw, 40px);
     font-weight: 600;
     letter-spacing: 2px;
+    text-align: center;
   }
 }
 
@@ -175,11 +176,7 @@ const onRegistr = async () => {
   }
 
   .logo {
-    position: absolute;
-    right: -70px;
-    top: 50%;
-    transform: translateY(-50%);
-    rotate: -90deg;
+    text-align: center;
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- move the LibraryApp heading above the login and registration forms
- remove rotated positioning styles so the heading stays centered across viewports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3f4cb1de48320bdd7c768c2d637bd