### PR TITLE
Add admin reservation search functionality

### DIFF
--- a/components/all/CustomTable.vue
+++ b/components/all/CustomTable.vue
@@ -13,6 +13,10 @@ const props = defineProps({
     type: Array,
     required: true,
   },
+  emptyMessage: {
+    type: String,
+    default: 'Нет зарезервированных книг'
+  },
     isUser: {
     type: Boolean,
     default: true
@@ -186,7 +190,7 @@ const tableHeaders = computed(() => ['№', ...props.headers.map(header => heade
     </div>
   </div>
   <div v-else class="text-center py-8 text-gray-500">
-    Нет зарезервированных книг
+    {{ emptyMessage }}
   </div>
 </template>
 

--- a/stores/reservation.ts
+++ b/stores/reservation.ts
@@ -60,11 +60,12 @@ export const useReservationStore = defineStore('reservation', {
                 console.log(e)
             }
         },
-        async getAllReservations()
+        async getAllReservations(user?: string)
         {
             const store = useGlobalStore()
             try{
-                const response = await fetch(`http://127.0.0.1:8000/api/admin/reservations`, {
+                const query = user ? `?user=${encodeURIComponent(user)}` : ''
+                const response = await fetch(`http://127.0.0.1:8000/api/admin/reservations${query}`, {
                     headers: {
                         Authorization: `Bearer ${store.token}`,
                         accept: 'application/json',
@@ -77,8 +78,9 @@ export const useReservationStore = defineStore('reservation', {
                 }
                 const data = await response.json()
                 this.all_reservations = data.data
-            }catch (e){
-                console.log(error)
+            }catch (error){
+                console.error(error)
+                this.all_reservations = []
             }
         },
         async canceledReservBook(book_id: number, user_id: number)


### PR DESCRIPTION
## Summary
- add a search bar to the admin reservations page to filter bookings by user name
- update the reservations store to request filtered data from /api/admin/reservations with an optional user query
- allow the shared table component to show a contextual empty-state message when no records match the search

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e4012b7f90832080d5157b01de140b