### PR TITLE
feat: refresh interface with vibrant theme

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,7 +1,10 @@
 <template>
   <div>
     <!-- Показываем загрузку, пока инициализация не завершена -->
-    <div v-if="!isInitialized" class="loading">Загрузка...</div>
+    <div v-if="!isInitialized" class="loading">
+      <span class="loading__spinner"></span>
+      <p class="loading__text">Загружаем библиотеку будущего...</p>
+    </div>
     <!-- Рендерим содержимое только после инициализации -->
     <nuxt-layout v-else>
       <nuxt-page />
@@ -69,10 +72,41 @@ onBeforeUnmount(() => {
 <style scoped>
 .loading {
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
+  gap: 18px;
   height: 100vh;
-  font-size: 1.5rem;
-  color: #333;
+  color: #e2e8f0;
+  background:
+    radial-gradient(120% 120% at 0% 0%, rgba(99, 102, 241, 0.4) 0%, rgba(15, 23, 42, 0) 60%),
+    radial-gradient(80% 80% at 100% 0%, rgba(244, 114, 182, 0.25) 0%, rgba(4, 8, 21, 0) 65%),
+    radial-gradient(120% 120% at 50% 100%, rgba(56, 189, 248, 0.18) 0%, rgba(4, 8, 21, 0) 70%),
+    linear-gradient(180deg, #020617 0%, #050b19 45%, #030617 100%);
+}
+
+.loading__spinner {
+  width: 54px;
+  height: 54px;
+  border-radius: 50%;
+  border: 4px solid rgba(148, 163, 184, 0.25);
+  border-top-color: rgba(129, 140, 248, 0.9);
+  animation: spin 0.9s linear infinite;
+}
+
+.loading__text {
+  font-size: 1.1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 </style>

--- a/assets/scss/_vars.scss
+++ b/assets/scss/_vars.scss
@@ -1,9 +1,9 @@
-$bg: #F0F4F8;
-$main: #2C3E50  ;
-$accent: #6A5ACD ;
-$btn-default: #6A5ACD ;
-$btn-hover: #7B68EE  ;
-$btn-active: #5D4AD0  ;
-$link: #4A68AD  ;
-$link-hover: #5A78BD ;
-$link-active: #6A7B8D ;
+$bg: #040815;
+$main: #e2e8f0;
+$accent: #6366f1;
+$btn-default: #6366f1;
+$btn-hover: #8b5cf6;
+$btn-active: #4f46e5;
+$link: #a5b4fc;
+$link-hover: #c4b5fd;
+$link-active: #818cf8;

--- a/assets/scss/global.scss
+++ b/assets/scss/global.scss
@@ -1,39 +1,57 @@
+@import url("https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap");
 @import "./vars";
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 body{
-  background: $bg;
+  font-family: 'Manrope', 'Inter', system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    radial-gradient(120% 120% at 0% 0%, rgba(99, 102, 241, 0.4) 0%, rgba(15, 23, 42, 0) 60%),
+    radial-gradient(80% 80% at 100% 0%, rgba(244, 114, 182, 0.25) 0%, rgba(4, 8, 21, 0) 65%),
+    radial-gradient(120% 120% at 50% 100%, rgba(56, 189, 248, 0.18) 0%, rgba(4, 8, 21, 0) 70%),
+    linear-gradient(180deg, #020617 0%, #050b19 45%, #030617 100%);
   color: $main;
   min-height: 100%;
+  line-height: 1.6;
+  letter-spacing: 0.015em;
 }
 a{
   text-decoration: none;
-  color: inherit;
+  color: $link;
+  transition: color 0.2s ease, text-shadow 0.2s ease;
+}
+a:hover{
+  color: $link-hover;
+  text-shadow: 0 0 18px rgba(99, 102, 241, 0.6);
 }
 p, h1, h2, h3, h4, h5, h6{
   padding: 0;
   margin: 0;
 }
+h1, h2, h3, h4, h5, h6{
+  color: #f8fafc;
+  font-weight: 600;
+}
 h4{
-  font-size: 30px;
-  font-weight: 700;
+  font-size: clamp(1.5rem, 1.8vw, 2rem);
   margin-bottom: 40px;
 }
 ul{
   list-style: none;
 }
 .error{
-  color: red;
-  font-weight: 500;
-  font-size: 24px;
+  color: #fda4af;
+  font-weight: 600;
+  font-size: 1.35rem;
   margin-bottom: 10px;
   margin-top: 10px;
   text-align: center;
 }
 .main{
-  margin: 0 20px;
+  margin: 0 auto;
+  width: min(1180px, 100%);
+  padding: clamp(1.5rem, 4vw, 3rem);
   overflow: hidden;
 }
 .swiper{
@@ -41,8 +59,8 @@ ul{
 }
 .books {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: clamp(18px, 3vw, 32px);
   align-self: center;
   align-items: stretch;
   align-content: stretch;
@@ -55,38 +73,36 @@ ul{
 .books > * {
   display: flex;
   height: 100%;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 22px;
+  padding: 18px;
+  box-shadow: 0 24px 48px -32px rgba(99, 102, 241, 0.5);
+  backdrop-filter: blur(12px);
 }
 
 @media (min-width: 640px) {
   .books {
-    grid-template-columns: repeat(2, minmax(180px, 1fr));
-    gap: 24px;
+    grid-template-columns: repeat(2, minmax(220px, 1fr));
   }
 }
 
 @media (min-width: 768px) {
   .books {
-    grid-template-columns: repeat(3, minmax(200px, 1fr));
-  }
-}
-
-@media (min-width: 1024px) {
-  .books {
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 32px;
+    grid-template-columns: repeat(3, minmax(220px, 1fr));
   }
 }
 
 @media (min-width: 1280px) {
   .books {
-    grid-template-columns: repeat(5, minmax(220px, 1fr));
+    grid-template-columns: repeat(4, minmax(240px, 1fr));
   }
 }
 
 .button-container {
   display: flex;
-  justify-content: center; /* Выравнивание по горизонтали */
-  margin-top: 40px; /* Отступ сверху */
+  justify-content: center;
+  margin-top: clamp(28px, 6vw, 48px);
 }
 .load{
   text-align: center;
@@ -94,27 +110,35 @@ ul{
 
 .btn {
   cursor: pointer;
-  background: #6A5ACD;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.95), rgba(147, 51, 234, 0.9));
   text-transform: uppercase;
-  font-size: 24px;
-  padding: 10px 20px;
-  color: #fff;
+  font-size: clamp(0.95rem, 2.2vw, 1.15rem);
+  padding: 12px 26px;
+  color: #f8fafc;
   border: none;
-  border-radius: 5px;
+  border-radius: 9999px;
+  letter-spacing: 0.08em;
+  box-shadow: 0 20px 45px -25px rgba(129, 140, 248, 0.9);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 .btn:hover {
-  background: #7B68EE;
+  transform: translateY(-2px);
+  box-shadow: 0 22px 48px -22px rgba(129, 140, 248, 0.95);
 }
 iframe{
   width: 100%;
   height: 600px;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.65);
+  box-shadow: 0 18px 44px -30px rgba(56, 189, 248, 0.45);
 }
 .v-application{
   background: none !important;
   color: inherit !important;
 }
 .bg-main{
-  background: #6A5ACD;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.95), rgba(14, 165, 233, 0.85));
 }
 .loader-container {
   position: fixed;
@@ -125,17 +149,18 @@ iframe{
   display: flex;
   justify-content: center;
   align-items: center;
-  background: rgba(255, 255, 255, 0.7); /* Полупрозрачный фон */
+  background: rgba(2, 6, 23, 0.78);
+  backdrop-filter: blur(14px);
   z-index: 1000;
 }
 
 .spinner {
-  border: 4px solid #f3f3f3; /* Светлый цвет */
-  border-top: 4px solid #3498db; /* Цветная верхняя часть */
+  border: 4px solid rgba(148, 163, 184, 0.25);
+  border-top: 4px solid rgba(129, 140, 248, 0.9);
   border-radius: 50%;
   width: 50px;
   height: 50px;
-  animation: spin 1s linear infinite;
+  animation: spin 0.9s linear infinite;
 }
 
 /* Анимация вращения */

--- a/components/layout/Footer.vue
+++ b/components/layout/Footer.vue
@@ -3,96 +3,83 @@
 </script>
 
 <template>
-  <div class="footer">
-    <div class="logo">
-      <NuxtLink to="/">LibraryApp</NuxtLink>
+  <footer class="relative overflow-hidden rounded-3xl border border-white/10 bg-slate-900/60 px-6 py-8 text-slate-200 shadow-xl shadow-indigo-500/20 backdrop-blur-2xl">
+    <div class="pointer-events-none absolute inset-0">
+      <div class="absolute -left-16 top-1/2 h-40 w-40 -translate-y-1/2 rounded-full bg-indigo-500/20 blur-3xl"></div>
+      <div class="absolute right-[-80px] top-0 h-48 w-48 rounded-full bg-sky-400/20 blur-3xl"></div>
+      <div class="absolute bottom-[-120px] left-1/3 h-56 w-56 rounded-full bg-fuchsia-500/10 blur-3xl"></div>
     </div>
-    <div class="footer__info">
-      <ul>
-        <li>Контакты</li>
-        <li><a href="">библиотека@example.com</a></li>
-        <li><a href="">Телефон: +7 (123) 456-78-90</a></li>
-        <li><a href="">Рабочие часы: Пн-Пт с 9:00 до 18:00</a></li>
-      </ul>
+
+    <div class="relative flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+      <div class="space-y-3">
+        <NuxtLink
+            to="/"
+            class="inline-block bg-gradient-to-r from-indigo-300 via-sky-200 to-purple-300 bg-clip-text text-2xl font-semibold text-transparent"
+        >LibraryApp</NuxtLink>
+        <p class="max-w-md text-sm text-slate-300/80">
+          Цифровое пространство для поиска вдохновляющих историй и управления библиотекой нового поколения.
+        </p>
+      </div>
+      <div class="grid gap-4 text-sm sm:grid-cols-2 sm:gap-6">
+        <div class="space-y-2">
+          <h3 class="text-xs uppercase tracking-[0.3em] text-indigo-200/80">Контакты</h3>
+          <ul class="space-y-1.5 text-slate-200/90">
+            <li class="flex items-center gap-2">
+              <span class="inline-flex h-6 w-6 items-center justify-center rounded-full bg-indigo-500/30 text-indigo-100">
+                <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.005 1.875l-7.5 5a2.25 2.25 0 01-2.49 0l-7.5-5a2.25 2.25 0 01-1.005-1.875V6.75" />
+                </svg>
+              </span>
+              <a href="mailto:библиотека@example.com" class="transition hover:text-indigo-200">библиотека@example.com</a>
+            </li>
+            <li class="flex items-center gap-2">
+              <span class="inline-flex h-6 w-6 items-center justify-center rounded-full bg-indigo-500/30 text-indigo-100">
+                <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 6.75l7.5 4.5 7.5-4.5m-15 0A2.25 2.25 0 013.75 4.5h16.5a2.25 2.25 0 012.25 2.25v10.5a2.25 2.25 0 01-2.25 2.25H3.75a2.25 2.25 0 01-2.25-2.25z" />
+                </svg>
+              </span>
+              <a href="tel:+71234567890" class="transition hover:text-indigo-200">Телефон: +7 (123) 456-78-90</a>
+            </li>
+            <li class="flex items-center gap-2">
+              <span class="inline-flex h-6 w-6 items-center justify-center rounded-full bg-indigo-500/30 text-indigo-100">
+                <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m5.25 0a9.75 9.75 0 11-19.5 0 9.75 9.75 0 0119.5 0z" />
+                </svg>
+              </span>
+              <span>Пн-Пт: 9:00 – 18:00</span>
+            </li>
+          </ul>
+        </div>
+        <div class="space-y-2">
+          <h3 class="text-xs uppercase tracking-[0.3em] text-indigo-200/80">Мы рядом</h3>
+          <ul class="space-y-1.5 text-slate-200/90">
+            <li class="flex items-center gap-2">
+              <span class="inline-flex h-6 w-6 items-center justify-center rounded-full bg-sky-500/30 text-sky-100">
+                <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 3.75l-7.5 7.5 7.5 7.5m1.5-15l7.5 7.5-7.5 7.5" />
+                </svg>
+              </span>
+              <NuxtLink to="/catalog" class="transition hover:text-indigo-200">Каталог книг</NuxtLink>
+            </li>
+            <li class="flex items-center gap-2">
+              <span class="inline-flex h-6 w-6 items-center justify-center rounded-full bg-sky-500/30 text-sky-100">
+                <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6.75h3a2.25 2.25 0 012.25 2.25v8.25a2.25 2.25 0 01-2.25 2.25H5.25a2.25 2.25 0 01-2.25-2.25V9a2.25 2.25 0 012.25-2.25h3m7.5 0V5.25a3.75 3.75 0 00-7.5 0V6.75m7.5 0h-7.5" />
+                </svg>
+              </span>
+              <NuxtLink to="/auth/login" class="transition hover:text-indigo-200">Вход и регистрация</NuxtLink>
+            </li>
+            <li class="flex items-center gap-2">
+              <span class="inline-flex h-6 w-6 items-center justify-center rounded-full bg-sky-500/30 text-sky-100">
+                <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-9 5.25h9" />
+                </svg>
+              </span>
+              <NuxtLink to="/recomendation" class="transition hover:text-indigo-200">ИИ рекомендации</NuxtLink>
+            </li>
+          </ul>
+        </div>
+      </div>
     </div>
-  </div>
+  </footer>
 </template>
-
-<style scoped>
-.footer {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: clamp(8px, 2vw, 16px);
-  padding: clamp(16px, 4vw, 28px);
-  background-color: #f5f5f5;
-  border-top: 1px solid #ddd;
-  margin-top: clamp(40px, 8vw, 100px);
-  max-height: 260px;
-  overflow: auto;
-  box-sizing: border-box;
-  width: 100%;
-  flex-shrink: 0;
-
-  .logo a {
-    font-size: clamp(18px, 3vw, 24px);
-    font-weight: bold;
-    text-decoration: none;
-    color: #4A68AD;
-  }
-
-  .footer__info {
-    width: 100%;
-
-    ul {
-      display: flex;
-      flex-direction: column;
-      row-gap: 6px;
-      width: 100%;
-      text-align: left;
-
-      li {
-        font-size: clamp(14px, 2.2vw, 16px);
-        color: #2C3E50;
-        word-break: break-word;
-      }
-
-      li:first-child {
-        font-size: clamp(12px, 1.8vw, 14px);
-        color: #4c5e71;
-      }
-    }
-  }
-}
-
-@media (min-width: 768px) {
-  .footer {
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-    gap: 20px;
-    padding: 24px 32px;
-
-    .footer__info {
-      width: auto;
-
-      ul {
-        width: auto;
-        text-align: left;
-        row-gap: 4px;
-
-        li {
-          font-size: 18px;
-        }
-
-        li:first-child {
-          font-size: 16px;
-        }
-      }
-    }
-  }
-}
-a:hover{
-  color: #5A78BD;
-}
-</style>

--- a/components/layout/Header.vue
+++ b/components/layout/Header.vue
@@ -1,65 +1,84 @@
 <template>
-  <header class="flex items-center justify-between px-4 py-2 bg-gray-100 border-b border-gray-200 relative z-10">
+  <header
+      class="relative flex items-center justify-between gap-4 rounded-3xl border border-white/10 bg-white/5 px-4 py-3 text-slate-100 shadow-lg shadow-indigo-500/20 backdrop-blur-2xl transition-colors sm:gap-6 sm:px-6"
+  >
     <!-- Бургер или логотип -->
     <div class="flex items-center">
       <!-- Бургер на мобиле -->
       <button
           @click="mobileMenuOpen = !mobileMenuOpen"
-          class="md:hidden focus:outline-none mr-2"
+          class="mr-2 rounded-full border border-white/10 bg-white/10 p-2 text-slate-100 transition hover:bg-white/20 md:hidden"
           aria-label="Открыть меню"
       >
-        <svg v-if="!mobileMenuOpen" xmlns="http://www.w3.org/2000/svg" class="w-8 h-8 text-indigo-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <svg v-if="!mobileMenuOpen" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
         </svg>
-        <svg v-else xmlns="http://www.w3.org/2000/svg" class="w-8 h-8 text-indigo-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <svg v-else xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
         </svg>
       </button>
       <!-- Логотип на десктопе -->
-      <NuxtLink to="/" class="hidden md:block text-2xl font-bold text-indigo-600 select-none">LibraryApp</NuxtLink>
+      <NuxtLink
+          to="/"
+          class="hidden select-none bg-gradient-to-r from-indigo-400 via-sky-300 to-purple-400 bg-clip-text text-2xl font-semibold text-transparent md:block"
+      >LibraryApp</NuxtLink>
     </div>
 
     <!-- Навигация (десктоп) -->
-    <nav class="hidden md:flex flex-1 justify-center items-center space-x-6">
-      <NuxtLink to="/catalog" class="text-indigo-600 hover:text-indigo-700">Каталог</NuxtLink>
-      <NuxtLink to="/about" class="text-indigo-600 hover:text-indigo-700">О нас</NuxtLink>
+    <nav class="hidden flex-1 items-center justify-center space-x-5 text-sm font-medium md:flex">
+      <NuxtLink to="/catalog" class="transition hover:text-indigo-200">Каталог</NuxtLink>
+      <NuxtLink to="/about" class="transition hover:text-indigo-200">О нас</NuxtLink>
       <div class="relative">
-        <button @click="isSearched = true" class="px-2 py-1 rounded hover:bg-indigo-100">🔍</button>
+        <button @click="isSearched = true" class="rounded-full bg-white/10 px-3 py-2 transition hover:bg-white/20">🔍</button>
       </div>
-      <NuxtLink to="/reservations" v-if="store.currentUser?.role==='Admin'" class="text-indigo-600 hover:text-indigo-700">Бронирования</NuxtLink>
-      <NuxtLink to="/my-reservations" v-else class="text-indigo-600 hover:text-indigo-700">Мои бронирования</NuxtLink>
-      <NuxtLink to="/recomendation" class="text-indigo-600 hover:text-indigo-700">ИИ Рекомендации</NuxtLink>
-      <a href="/random/book" @click.prevent="goToRandom" class="text-indigo-600 hover:text-indigo-700">Случайная книга</a>
+      <NuxtLink
+          to="/reservations"
+          v-if="store.currentUser?.role==='Admin'"
+          class="transition hover:text-indigo-200"
+      >Бронирования</NuxtLink>
+      <NuxtLink to="/my-reservations" v-else class="transition hover:text-indigo-200">Мои бронирования</NuxtLink>
+      <NuxtLink to="/recomendation" class="transition hover:text-indigo-200">ИИ Рекомендации</NuxtLink>
+      <a href="/random/book" @click.prevent="goToRandom" class="transition hover:text-indigo-200">Случайная книга</a>
       <NuxtLink
           v-if="store.currentUser?.role==='Admin'"
           to="/admin/books/create"
-          class="text-indigo-600 hover:text-indigo-700"
+          class="transition hover:text-indigo-200"
       >Добавить книгу</NuxtLink>
-      <NuxtLink to="/import-files" v-if="store.currentUser?.role==='Admin'" class="text-indigo-600 hover:text-indigo-700">Импортировать книги</NuxtLink>
+      <NuxtLink to="/import-files" v-if="store.currentUser?.role==='Admin'" class="transition hover:text-indigo-200">Импортировать книги</NuxtLink>
     </nav>
 
     <!-- Мобильное меню -->
     <transition name="fade">
       <nav
           v-if="mobileMenuOpen"
-          class="fixed inset-0 bg-gray-900 bg-opacity-80 flex flex-col items-center justify-center space-y-6 z-50 md:hidden"
+          class="fixed inset-0 z-50 flex flex-col items-center justify-center space-y-6 bg-slate-950/80 px-6 py-8 text-lg text-slate-100 backdrop-blur-xl md:hidden"
       >
-        <NuxtLink @click="closeMobile" to="/" class="text-lg text-white">Домой</NuxtLink>
-        <NuxtLink @click="closeMobile" to="/catalog" class="text-lg text-white">Каталог</NuxtLink>
-        <NuxtLink @click="closeMobile" to="/about" class="text-lg text-white">О нас</NuxtLink>
-        <button @click="showSearchMobile" class="text-lg text-white">🔍 Поиск</button>
-        <NuxtLink @click="closeMobile" to="/reservations" v-if="store.currentUser?.role==='Admin'" class="text-lg text-white">Бронирования</NuxtLink>
-        <NuxtLink @click="closeMobile" to="/my-reservations" v-else class="text-lg text-white">Мои бронирования</NuxtLink>
-        <NuxtLink @click="closeMobile" to="/recomendation" class="text-lg text-white">ИИ Рекомендации</NuxtLink>
-        <a @click.prevent="goToRandomMobile" href="/random/book" class="text-lg text-white">Случайная книга</a>
+        <NuxtLink @click="closeMobile" to="/" class="transition hover:text-indigo-200">Домой</NuxtLink>
+        <NuxtLink @click="closeMobile" to="/catalog" class="transition hover:text-indigo-200">Каталог</NuxtLink>
+        <NuxtLink @click="closeMobile" to="/about" class="transition hover:text-indigo-200">О нас</NuxtLink>
+        <button @click="showSearchMobile" class="rounded-full bg-white/10 px-4 py-2 transition hover:bg-white/20">🔍 Поиск</button>
+        <NuxtLink
+            @click="closeMobile"
+            to="/reservations"
+            v-if="store.currentUser?.role==='Admin'"
+            class="transition hover:text-indigo-200"
+        >Бронирования</NuxtLink>
+        <NuxtLink @click="closeMobile" to="/my-reservations" v-else class="transition hover:text-indigo-200">Мои бронирования</NuxtLink>
+        <NuxtLink @click="closeMobile" to="/recomendation" class="transition hover:text-indigo-200">ИИ Рекомендации</NuxtLink>
+        <a @click.prevent="goToRandomMobile" href="/random/book" class="transition hover:text-indigo-200">Случайная книга</a>
         <NuxtLink
             v-if="store.currentUser?.role==='Admin'"
             @click="closeMobile"
             to="/admin/books/create"
-            class="block w-full text-lg text-white px-3 py-2 rounded-md transition text-center"
-        >Добавить книгу</NuxtLink>
-        <NuxtLink @click="closeMobile" to="/import-files" v-if="store.currentUser?.role==='Admin'" class="text-lg text-white">Импортировать книги</NuxtLink>
-        <button @click="closeMobile" class="absolute top-4 right-4 text-white text-3xl">&times;</button>
+            class="block w-full rounded-full border border-white/10 bg-white/10 px-4 py-2 text-center text-base transition hover:bg-white/20"
+        >Добавить нигу</NuxtLink>
+        <NuxtLink
+            @click="closeMobile"
+            to="/import-files"
+            v-if="store.currentUser?.role==='Admin'"
+            class="transition hover:text-indigo-200"
+        >Импортировать книги</NuxtLink>
+        <button @click="closeMobile" class="absolute right-5 top-5 text-4xl text-slate-200">&times;</button>
       </nav>
     </transition>
 
@@ -67,29 +86,29 @@
     <transition name="fade">
       <div
           v-if="isSearched"
-          class="fixed inset-0 flex items-start sm:items-center justify-center bg-black bg-opacity-50 z-50 px-4 sm:px-0 pt-12 sm:pt-0"
+          class="fixed inset-0 z-50 flex items-start justify-center bg-slate-950/80 px-4 pt-12 text-slate-100 backdrop-blur-xl sm:items-center sm:px-0 sm:pt-0"
       >
-        <div class="bg-white p-4 sm:p-6 rounded-lg shadow-lg w-full max-w-md relative">
-          <button @click="closeInput" class="absolute top-2 right-2">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <div class="relative w-full max-w-md rounded-3xl border border-white/10 bg-slate-900/80 p-5 shadow-2xl shadow-indigo-500/20 backdrop-blur-xl sm:p-6">
+          <button @click="closeInput" class="absolute right-4 top-4 text-slate-300 transition hover:text-indigo-200">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
             </svg>
           </button>
-          <div class="flex flex-col space-y-3 w-full">
+          <div class="flex w-full flex-col space-y-4">
             <!-- Поле поиска с кнопками -->
             <div class="relative flex items-center">
               <input
                   v-model="searchQuery"
                   type="text"
                   placeholder="Поиск книг..."
-                  class="flex-1 p-3 pr-16 text-sm sm:text-base border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-300 focus:border-indigo-300"
+                  class="flex-1 rounded-full border border-white/10 bg-slate-900/60 p-3 pr-20 text-sm text-slate-100 transition placeholder:text-slate-400 focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-300"
                   @keyup.enter="onSearch"
               />
               <!-- Кнопка очистки -->
               <button
                   v-if="searchQuery"
                   @click="searchQuery = ''"
-                  class="absolute right-10 p-1 text-gray-500 hover:text-gray-700 transition-colors"
+                  class="absolute right-12 rounded-full p-1 text-slate-400 transition hover:text-indigo-200"
               >
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
@@ -98,7 +117,7 @@
               <!-- Кнопка поиска -->
               <button
                   @click="onSearch"
-                  class="absolute right-2 p-1 text-indigo-600 hover:text-indigo-800 transition-colors"
+                  class="absolute right-3 flex h-9 w-9 items-center justify-center rounded-full bg-indigo-500/80 text-white transition hover:bg-indigo-400"
               >
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
@@ -107,23 +126,25 @@
             </div>
 
             <!-- Нижний блок с настройками -->
-            <div class="flex flex-col xs:flex-row xs:items-center xs:justify-between gap-3">
-              <div class="flex flex-wrap items-center gap-2 sm:gap-3">
+            <div class="flex flex-col gap-3 xs:flex-row xs:items-center xs:justify-between">
+              <div class="flex flex-wrap items-center gap-3">
                 <!-- Переключатель AI поиска -->
-                <label class="inline-flex items-center cursor-pointer">
+                <label class="inline-flex cursor-pointer items-center gap-2 text-xs sm:text-sm">
                   <input v-model="isNpl" type="checkbox" class="sr-only peer">
-                  <div class="relative w-10 h-5 sm:w-10 sm:h-5 bg-gray-300 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-indigo-600"></div>
-                  <span class="ml-1 sm:ml-2 text-xs sm:text-sm font-medium text-gray-700">AI Поиск</span>
+                  <div class="relative h-5 w-10 rounded-full bg-slate-700 transition peer-focus:outline-none peer-checked:bg-indigo-500">
+                    <span class="absolute left-[3px] top-1/2 h-4 w-4 -translate-y-1/2 rounded-full bg-slate-200 transition peer-checked:translate-x-5 peer-checked:bg-white"></span>
+                  </div>
+                  <span class="font-medium text-slate-200">AI Поиск</span>
                 </label>
 
                 <!-- Иконка с подсказкой -->
-                <div class="relative group">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-indigo-600 cursor-help" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <div class="group relative">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 cursor-help text-indigo-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
                   </svg>
-                  <div class="absolute z-10 left-1/2 transform -translate-x-1/2 bottom-full mb-2 w-56 sm:w-64 bg-gray-800 text-white text-xs sm:text-sm rounded-lg py-2 px-3 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 shadow-lg whitespace-normal">
+                  <div class="absolute bottom-full left-1/2 z-10 w-60 -translate-x-1/2 rounded-2xl border border-white/10 bg-slate-900/90 px-4 py-3 text-xs text-slate-100 opacity-0 shadow-xl shadow-indigo-500/20 backdrop-blur-xl transition-all duration-200 group-hover:visible group-hover:translate-y-[-4px] group-hover:opacity-100 sm:w-64 sm:text-sm">
                     Включает продвинутый поиск. Вы можете написать описание книги, и система подберёт книги с помощью ИИ.
-                    <div class="absolute top-full left-1/2 -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-b-0 border-t-4 border-gray-800 border-solid"></div>
+                    <div class="absolute top-full left-1/2 -translate-x-1/2 h-3 w-3 rotate-45 border-r border-b border-white/10 bg-slate-900/90"></div>
                   </div>
                 </div>
               </div>
@@ -138,19 +159,36 @@
       <template v-if="isAuthenticated">
         <div class="relative">
           <div @click="toggleDropdown" class="cursor-pointer">
-            <img src="/img/products-2.jpg" alt="Profile" class="w-10 h-10 rounded-full" />
+            <img src="/img/products-2.jpg" alt="Profile" class="h-10 w-10 rounded-full border border-white/20 shadow-lg shadow-indigo-500/20" />
           </div>
-          <ul v-if="isDropdownOpen" class="absolute right-0 mt-2 w-48 bg-white border border-gray-200 rounded-md shadow-lg">
-            <li class="px-4 py-2 hover:bg-gray-100"><NuxtLink :to="`/user/${store.currentUser.id}`" @click="closeDropdown">Мой профиль</NuxtLink></li>
-            <li class="px-4 py-2 hover:bg-gray-100"><NuxtLink to="/history" @click="closeDropdown">История бронирований</NuxtLink></li>
-            <li class="px-4 py-2 hover:bg-gray-100"><NuxtLink to="/favorites" @click="closeDropdown">Избранные книги</NuxtLink></li>
-            <li class="px-4 py-2 text-red-500 hover:bg-gray-100"><button @click="handleLogout">Выйти</button></li>
+          <ul
+              v-if="isDropdownOpen"
+              class="absolute right-0 mt-3 w-52 rounded-2xl border border-white/10 bg-slate-900/90 p-2 text-sm text-slate-100 shadow-xl shadow-indigo-500/20 backdrop-blur-xl"
+          >
+            <li class="rounded-xl px-4 py-2 transition hover:bg-white/10">
+              <NuxtLink :to="`/user/${store.currentUser.id}`" @click="closeDropdown">Мой профиль</NuxtLink>
+            </li>
+            <li class="rounded-xl px-4 py-2 transition hover:bg-white/10">
+              <NuxtLink to="/history" @click="closeDropdown">История бронирований</NuxtLink>
+            </li>
+            <li class="rounded-xl px-4 py-2 transition hover:bg-white/10">
+              <NuxtLink to="/favorites" @click="closeDropdown">Избранные книги</NuxtLink>
+            </li>
+            <li class="rounded-xl px-4 py-2 text-rose-300 transition hover:bg-white/10">
+              <button @click="handleLogout">Выйти</button>
+            </li>
           </ul>
         </div>
       </template>
       <template v-else>
-        <NuxtLink to="/auth/login" class="px-3 py-1 bg-indigo-600 text-white rounded-md">Войти</NuxtLink>
-        <NuxtLink to="/auth/register" class="px-3 py-1 bg-indigo-600 text-white rounded-md">Зарегистрироваться</NuxtLink>
+        <NuxtLink
+            to="/auth/login"
+            class="rounded-full border border-indigo-400/50 bg-indigo-500/80 px-4 py-2 text-sm font-semibold text-white shadow shadow-indigo-500/30 transition hover:bg-indigo-400"
+        >Войти</NuxtLink>
+        <NuxtLink
+            to="/auth/register"
+            class="rounded-full border border-sky-400/40 bg-sky-500/70 px-4 py-2 text-sm font-semibold text-white shadow shadow-sky-500/30 transition hover:bg-sky-400"
+        >Зарегистрироваться</NuxtLink>
       </template>
     </div>
   </header>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -5,24 +5,26 @@ import Footer from "~/components/layout/Footer.vue";
 </script>
 
 <template>
-  <div class="layout">
-    <Header />
-    <main class="layout__content">
-      <slot></slot>
-    </main>
-    <Footer />
+  <div class="relative min-h-screen overflow-hidden text-slate-100">
+    <div class="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
+      <div class="absolute -left-32 -top-40 h-72 w-72 rounded-full bg-indigo-500/20 blur-3xl sm:h-80 sm:w-80"></div>
+      <div class="absolute bottom-[-180px] left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-violet-500/10 blur-3xl"></div>
+      <div class="absolute right-[-120px] top-1/3 h-80 w-80 rounded-full bg-sky-400/20 blur-3xl"></div>
+      <div class="absolute left-[20%] top-[60%] h-64 w-64 rounded-full bg-fuchsia-500/10 blur-3xl"></div>
+    </div>
+
+    <div class="relative flex min-h-screen flex-col">
+      <div class="px-3 pt-4 sm:px-6 lg:px-10">
+        <Header />
+      </div>
+      <main class="relative z-10 flex-1 px-3 pb-12 pt-6 sm:px-6 lg:px-10">
+        <div class="mx-auto w-full max-w-7xl">
+          <slot></slot>
+        </div>
+      </main>
+      <div class="px-3 pb-6 sm:px-6 lg:px-10">
+        <Footer />
+      </div>
+    </div>
   </div>
 </template>
-
-<style scoped>
-.layout {
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-}
-
-.layout__content {
-  flex: 1 0 auto;
-  width: 100%;
-}
-</style>


### PR DESCRIPTION
## Summary
- restyled global palette, typography, and shared card styles to introduce a vibrant, futuristic aesthetic similar to the recommendations page
- redesigned the default layout along with the header and footer to use glassmorphism, gradients, and modern interactions across breakpoints
- refreshed the loading screen to align with the new branding and provide a more polished onboarding experience

## Testing
- npm run build *(fails: existing Vue SFC parser error in components/all/CustomTable.vue)*

------
https://chatgpt.com/codex/tasks/task_e_68e425dc84ac8320a7e91f71e1544d5d