### PR TITLE
Improve layout spacing and refresh overlays

### DIFF
--- a/components/all/CustomTable.vue
+++ b/components/all/CustomTable.vue
@@ -106,15 +106,15 @@ const tableHeaders = computed(() => ['№', ...props.headers.map(header => heade
 </script>
 
 <template>
-  <div v-if="rows.length" class="overflow-x-auto">
+  <div v-if="rows.length" class="overflow-x-auto rounded-3xl border border-white/10 bg-slate-950/40 shadow-xl shadow-indigo-500/20 backdrop-blur">
     <!-- Таблица -->
-    <table class="min-w-full table-auto border-collapse border border-gray-300 text-left shadow-lg">
+    <table class="min-w-full table-auto border-separate border-spacing-0 text-left text-sm text-slate-100">
       <thead>
-      <tr class="bg-main text-white">
+      <tr class="bg-white/5 text-indigo-100">
         <th
             v-for="(header, index) in tableHeaders"
             :key="index"
-            class="border border-gray-300 p-3 text-sm font-semibold uppercase tracking-wide"
+            class="border-b border-white/10 px-4 py-3 text-xs font-semibold uppercase tracking-wide first:rounded-tl-3xl last:rounded-tr-3xl"
         >
           {{ header }}
         </th>
@@ -124,15 +124,15 @@ const tableHeaders = computed(() => ['№', ...props.headers.map(header => heade
       <tr
           v-for="(row, rowIndex) in paginatedRows"
           :key="rowIndex"
-          class="hover:bg-gray-100 odd:bg-white even:bg-gray-50 transition-colors"
+          class="transition-colors odd:bg-white/5 even:bg-white/10 hover:bg-indigo-500/10"
       >
         <!-- Номер строки -->
-        <td class="border border-gray-300 p-3 text-gray-700 text-sm font-medium">
+        <td class="border-b border-white/5 px-4 py-3 text-sm font-semibold text-slate-100">
           {{ (currentPage - 1) * rowsPerPage + rowIndex + 1 }}
         </td>
 
         <!-- Название книги -->
-        <td class="border border-gray-300 p-3 text-gray-600 text-sm">
+        <td class="border-b border-white/5 px-4 py-3 text-sm text-slate-200">
           <NuxtLink :to="`/books/${row.book_id}`">
             {{ row.book_title }}
           </NuxtLink>
@@ -140,77 +140,77 @@ const tableHeaders = computed(() => ['№', ...props.headers.map(header => heade
         </td>
 
         <!-- Дата бронирования -->
-        <td class="border border-gray-300 p-3 text-gray-600 text-sm">
+        <td class="border-b border-white/5 px-4 py-3 text-sm text-slate-300">
           {{ formatDate(row.reservation_time) }}
         </td>
 
         <!-- Статус -->
-        <td class="border border-gray-300 p-3 text-gray-600 text-sm">
+        <td class="border-b border-white/5 px-4 py-3 text-sm text-slate-200">
           {{ row.status === 'active' ? 'Активна' : row.status === 'passed' ? 'Выдана' : row.status === 'expired'?'Просрочена':'Бронь отменена' }}
         </td>
 
         <!-- Пользователь (только для админа) -->
-        <td v-if="store.currentUser?.role==='Admin'" class="border border-gray-300 p-3 text-gray-600 text-sm">
+        <td v-if="store.currentUser?.role==='Admin'" class="border-b border-white/5 px-4 py-3 text-sm text-slate-200">
           {{ row.user.name }}
         </td>
 
         <!-- Кнопки действий -->
-        <td class="border border-gray-300 p-3 text-center space-y-1">
+        <td class="border-b border-white/5 px-4 py-3 text-center text-slate-100">
           <!-- Статус: отменена -->
           <span
               v-if="row.status === 'canceled'"
-              class="text-sm text-red-600 font-semibold"
+              class="text-sm font-semibold text-rose-300"
           >
     Бронь отменена
   </span>
 
           <!-- Статус: просрочена -->
-          <div v-else-if="row.status === 'expired'" class="flex flex-col justify-center items-center">
+          <div v-else-if="row.status === 'expired'" class="flex flex-col items-center justify-center gap-2">
             <span
-                class="text-sm text-yellow-600 font-semibold"
+                class="text-sm font-semibold text-amber-300"
             >
     Возврат просрочен
   </span>
             <button
-                class="bg-green-500 text-white py-1 px-4 rounded-md hover:bg-red-600 active:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-300 focus:ring-offset-1 transition"
+                class="rounded-full bg-emerald-500/90 px-4 py-1 text-sm font-semibold text-white shadow-md shadow-emerald-500/30 transition hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300/80"
                 @click="returnBook(row.book_id, row.user.id)"
             >
               Подтвердить возврат
             </button>
           </div>
           <!-- Статус: выдана -->
-          <div v-else-if="row.status === 'passed'" class="flex flex-col justify-center items-center">
+          <div v-else-if="row.status === 'passed'" class="flex flex-col items-center justify-center gap-2">
             <span
-                class="text-sm text-green-400 font-semibold">
+                class="text-sm font-semibold text-emerald-300">
     Книга выдана, возврат: {{row.reserved_until}}
   </span>
             <button
-                class="bg-green-500 text-white py-1 px-4 rounded-md hover:bg-red-600 active:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-300 focus:ring-offset-1 transition"
+                class="rounded-full bg-emerald-500/90 px-4 py-1 text-sm font-semibold text-white shadow-md shadow-emerald-500/30 transition hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300/80"
                 @click="returnBook(row.book_id, row.user.id)"
             >
               Подтвердить возврат
             </button>
           </div>
-          <div v-else-if="row.status === 'returned'" class="flex flex-col justify-center items-center">
+          <div v-else-if="row.status === 'returned'" class="flex flex-col items-center justify-center">
             <span
-                class="text-sm text-yellow-600 font-semibold"
+                class="text-sm font-semibold text-indigo-200"
             >
               Книга возвращена
             </span>
           </div>
 
           <!-- Статус: активная -->
-          <div v-else-if="row.status === 'active'" class="flex justify-center flex-wrap gap-2">
+          <div v-else-if="row.status === 'active'" class="flex flex-wrap justify-center gap-2">
             <button
                 @click="deleteRow(row.book_id, row.user.id)"
-                class="bg-red-500 text-white py-1 px-4 rounded-md hover:bg-red-600 active:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-300 focus:ring-offset-1 transition"
+                class="rounded-full bg-rose-500/90 px-4 py-1 text-sm font-semibold text-white shadow-md shadow-rose-500/30 transition hover:bg-rose-400 focus:outline-none focus:ring-2 focus:ring-rose-300/80"
             >
               Отменить бронь
             </button>
             <button
                 v-if="store.currentUser?.role === 'Admin'"
                 @click="issueBook(row.book_id, row.user.id)"
-                class="bg-green-500 text-white py-1 px-4 rounded-md hover:bg-green-600 active:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-300 focus:ring-offset-1 transition"
+                class="rounded-full bg-sky-500/90 px-4 py-1 text-sm font-semibold text-white shadow-md shadow-sky-500/30 transition hover:bg-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-300/80"
             >
               Выдать книгу
             </button>
@@ -221,25 +221,25 @@ const tableHeaders = computed(() => ['№', ...props.headers.map(header => heade
     </table>
 
     <!-- Пагинация -->
-    <div class="mt-4 flex justify-center items-center space-x-2">
+    <div class="mt-4 flex flex-wrap items-center justify-center gap-3 px-4 pb-4">
       <button
           @click="goToPrevious"
           :disabled="currentPage === 1"
-          class="bg-gray-300 text-gray-700 py-1 px-3 rounded-md hover:bg-gray-400 disabled:bg-gray-200 disabled:cursor-not-allowed"
+          class="rounded-full bg-white/10 px-4 py-1 text-sm font-medium text-slate-100 transition hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-40"
       >
         Назад
       </button>
-      <span class="text-gray-600 text-sm font-medium">Страница {{ currentPage }} из {{ totalPages }}</span>
+      <span class="text-sm font-medium text-slate-200">Страница {{ currentPage }} из {{ totalPages }}</span>
       <button
           @click="goToNext"
           :disabled="currentPage === totalPages"
-          class="bg-gray-300 text-gray-700 py-1 px-3 rounded-md hover:bg-gray-400 disabled:bg-gray-200 disabled:cursor-not-allowed"
+          class="rounded-full bg-white/10 px-4 py-1 text-sm font-medium text-slate-100 transition hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-40"
       >
         Вперед
       </button>
     </div>
   </div>
-  <div v-else class="text-center py-8 text-gray-500">
+  <div v-else class="py-8 text-center text-slate-300">
     {{ emptyMessage }}
   </div>
 </template>

--- a/components/history/ReservationHistory.vue
+++ b/components/history/ReservationHistory.vue
@@ -74,12 +74,12 @@ const goToPage = (page) => {
 // Получение класса для статуса
 const getStatusClass = (status) => {
   switch (status) {
-    case 'active': return 'bg-blue-100 text-blue-800';
-    case 'canceled': return 'bg-red-100 text-red-800';
-    case 'passed': return 'bg-purple-100 text-purple-800';
-    case 'returned': return 'bg-green-100 text-green-800';
-    case 'expired': return 'bg-amber-100 text-amber-800';
-    default: return 'bg-gray-100 text-gray-800';
+    case 'active': return 'bg-indigo-500/20 text-indigo-100';
+    case 'canceled': return 'bg-rose-500/20 text-rose-200';
+    case 'passed': return 'bg-emerald-500/20 text-emerald-100';
+    case 'returned': return 'bg-sky-500/20 text-sky-100';
+    case 'expired': return 'bg-amber-500/20 text-amber-100';
+    default: return 'bg-white/10 text-slate-100';
   }
 };
 
@@ -100,15 +100,15 @@ const getStatusText = (status) => {
   <div class="reservation-history">
     <!-- Фильтры -->
     <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-6 gap-4">
-      <h2 class="text-2xl font-bold text-gray-800">История бронирований</h2>
+      <h2 class="text-2xl font-bold text-slate-100">История бронирований</h2>
 
       <div class="flex items-center gap-4">
         <div class="flex items-center">
-          <label for="status-filter" class="mr-2 text-sm font-medium text-gray-700">Статус:</label>
+          <label for="status-filter" class="mr-2 text-sm font-medium text-slate-300">Статус:</label>
           <select
               id="status-filter"
               v-model="statusFilter"
-              class="border border-gray-300 rounded-md px-3 py-1 text-sm focus:ring-main focus:border-main"
+              class="rounded-xl border border-white/10 bg-slate-900/80 px-3 py-1 text-sm text-slate-100 shadow-inner shadow-indigo-500/10 focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-300"
           >
             <option
                 v-for="option in statusOptions"
@@ -123,58 +123,58 @@ const getStatusText = (status) => {
     </div>
 
     <!-- Таблица -->
-    <div class="overflow-x-auto bg-white rounded-lg shadow">
-      <table class="min-w-full divide-y divide-gray-200">
-        <thead class="bg-gray-50">
+    <div class="overflow-x-auto rounded-3xl border border-white/10 bg-slate-950/40 shadow-xl shadow-indigo-500/20 backdrop-blur">
+      <table class="min-w-full table-auto border-separate border-spacing-0 text-sm text-slate-100">
+        <thead class="bg-white/5 text-indigo-100">
         <tr>
-          <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          <th class="border-b border-white/10 px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider">
             Книга
           </th>
-          <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          <th class="border-b border-white/10 px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider">
             Срок сдачи
           </th>
-          <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          <th class="border-b border-white/10 px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider">
             Дата бронирования
           </th>
-          <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          <th class="border-b border-white/10 px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider">
             Статус
           </th>
-          <th v-if="isAdmin" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          <th v-if="isAdmin" class="border-b border-white/10 px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider">
             Пользователь
           </th>
         </tr>
         </thead>
-        <tbody class="bg-white divide-y divide-gray-200">
+        <tbody class="divide-y divide-white/5">
         <tr
             v-for="reservation in paginatedReservations"
             :key="reservation.reservation_time"
-            class="hover:bg-gray-50 transition-colors"
+            class="transition-colors odd:bg-white/5 even:bg-white/10 hover:bg-indigo-500/10"
         >
-          <td class="px-6 py-4 whitespace-nowrap">
-            <div class="text-sm font-medium text-gray-900">
+          <td class="px-6 py-4 text-sm font-medium text-slate-100">
+            <div>
               {{ reservation.book_title }}
             </div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+          <td class="px-6 py-4 text-sm text-slate-300">
             {{ reservation.reserved_until }}
           </td>
-          <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+          <td class="px-6 py-4 text-sm text-slate-300">
             {{ formatDate(reservation.reservation_time) }}
           </td>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-6 py-4">
               <span
                   :class="['px-2 py-1 inline-flex text-xs leading-5 font-semibold rounded-full', getStatusClass(reservation.status)]"
               >
                 {{ getStatusText(reservation.status) }}
               </span>
           </td>
-          <td v-if="isAdmin" class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+          <td v-if="isAdmin" class="px-6 py-4 text-sm text-slate-300">
             {{ reservation.user.name }} (ID: {{ reservation.user.id }})
           </td>
         </tr>
 
         <tr v-if="paginatedReservations.length === 0">
-          <td :colspan="isAdmin ? 5 : 4" class="px-6 py-4 text-center text-sm text-gray-500">
+          <td :colspan="isAdmin ? 5 : 4" class="px-6 py-4 text-center text-sm text-slate-300">
             Нет данных о бронированиях
           </td>
         </tr>
@@ -184,17 +184,17 @@ const getStatusText = (status) => {
 
     <!-- Пагинация -->
     <div class="mt-4 flex flex-col sm:flex-row items-center justify-between px-2">
-      <div class="text-sm text-gray-700 mb-2 sm:mb-0">
+      <div class="mb-2 text-sm text-slate-300 sm:mb-0">
         Показано с {{ (currentPage - 1) * rowsPerPage + 1 }} по
         {{ Math.min(currentPage * rowsPerPage, sortedReservations.length) }} из
         {{ sortedReservations.length }} записей
       </div>
 
-      <div class="flex space-x-1">
+      <div class="flex flex-wrap gap-2">
         <button
             @click="goToPage(currentPage - 1)"
             :disabled="currentPage === 1"
-            class="px-3 py-1 border border-gray-300 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+            class="rounded-full border border-white/10 bg-white/10 px-4 py-1 text-sm font-medium text-slate-100 transition hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-40"
         >
           Назад
         </button>
@@ -202,7 +202,7 @@ const getStatusText = (status) => {
         <template v-for="page in totalPages" :key="page">
           <button
               @click="goToPage(page)"
-              :class="['px-3 py-1 border rounded-md text-sm font-medium', currentPage === page ? 'bg-main border-main text-white' : 'border-gray-300 text-gray-700 bg-white hover:bg-gray-50']"
+              :class="['rounded-full border px-4 py-1 text-sm font-medium transition', currentPage === page ? 'border-indigo-400 bg-indigo-500/90 text-white shadow shadow-indigo-500/30' : 'border-white/10 bg-white/10 text-slate-200 hover:bg-white/20']"
           >
             {{ page }}
           </button>
@@ -211,7 +211,7 @@ const getStatusText = (status) => {
         <button
             @click="goToPage(currentPage + 1)"
             :disabled="currentPage === totalPages"
-            class="px-3 py-1 border border-gray-300 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+            class="rounded-full border border-white/10 bg-white/10 px-4 py-1 text-sm font-medium text-slate-100 transition hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-40"
         >
           Вперед
         </button>
@@ -222,10 +222,10 @@ const getStatusText = (status) => {
 
 <style scoped>
 .reservation-history {
-  @apply p-4 bg-gray-50 rounded-lg;
+  @apply rounded-3xl border border-white/10 bg-slate-950/20 p-4 shadow-lg shadow-indigo-500/10 backdrop-blur;
 }
 
 th {
-  @apply sticky top-0 z-10;
+  @apply sticky top-0 z-10 bg-slate-950/60 backdrop-blur;
 }
 </style>

--- a/components/layout/Header.vue
+++ b/components/layout/Header.vue
@@ -1,6 +1,6 @@
 <template>
   <header
-      class="relative flex items-center justify-between gap-4 rounded-3xl border border-white/10 bg-white/5 px-4 py-3 text-slate-100 shadow-lg shadow-indigo-500/20 backdrop-blur-2xl transition-colors sm:gap-6 sm:px-6"
+      class="relative z-30 flex items-center justify-between gap-4 rounded-3xl border border-white/10 bg-white/5 px-4 py-3 text-slate-100 shadow-lg shadow-indigo-500/20 backdrop-blur-2xl transition-colors sm:gap-6 sm:px-6"
   >
     <!-- Бургер или логотип -->
     <div class="flex items-center">
@@ -86,7 +86,7 @@
     <transition name="fade">
       <div
           v-if="isSearched"
-          class="fixed inset-0 z-50 flex items-start justify-center bg-slate-950/80 px-4 pt-12 text-slate-100 backdrop-blur-xl sm:items-center sm:px-0 sm:pt-0"
+          class="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 px-4 py-10 text-slate-100 backdrop-blur-xl sm:px-0"
       >
         <div class="relative w-full max-w-md rounded-3xl border border-white/10 bg-slate-900/80 p-5 shadow-2xl shadow-indigo-500/20 backdrop-blur-xl sm:p-6">
           <button @click="closeInput" class="absolute right-4 top-4 text-slate-300 transition hover:text-indigo-200">
@@ -163,7 +163,7 @@
           </div>
           <ul
               v-if="isDropdownOpen"
-              class="absolute right-0 mt-3 w-52 rounded-2xl border border-white/10 bg-slate-900/90 p-2 text-sm text-slate-100 shadow-xl shadow-indigo-500/20 backdrop-blur-xl"
+              class="absolute right-0 z-40 mt-3 w-52 rounded-2xl border border-white/10 bg-slate-900/90 p-2 text-sm text-slate-100 shadow-xl shadow-indigo-500/20 backdrop-blur-xl"
           >
             <li class="rounded-xl px-4 py-2 transition hover:bg-white/10">
               <NuxtLink :to="`/user/${store.currentUser.id}`" @click="closeDropdown">Мой профиль</NuxtLink>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -5,7 +5,7 @@ import Footer from "~/components/layout/Footer.vue";
 </script>
 
 <template>
-  <div class="relative min-h-screen overflow-hidden text-slate-100">
+  <div class="relative min-h-screen overflow-x-hidden text-slate-100">
     <div class="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
       <div class="absolute -left-32 -top-40 h-72 w-72 rounded-full bg-indigo-500/20 blur-3xl sm:h-80 sm:w-80"></div>
       <div class="absolute bottom-[-180px] left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-violet-500/10 blur-3xl"></div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -49,7 +49,7 @@ onMounted(() => {
 <template>
   <div>
     <!-- Hero Section -->
-    <section class="relative -mt-[170px] pb-12 pt-32">
+    <section class="relative pb-12 pt-24 sm:pt-28 lg:pt-32">
       <div class="mx-auto max-w-6xl">
         <div class="relative overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br from-slate-950/90 via-indigo-900/70 to-slate-950/80 px-6 py-16 text-center shadow-2xl shadow-indigo-500/20 sm:px-10 lg:px-16">
           <div class="pointer-events-none absolute -left-20 top-10 h-40 w-40 rounded-full bg-indigo-500/30 blur-3xl"></div>


### PR DESCRIPTION
## Summary
- lower the home page hero spacing so it no longer overlaps the navigation
- raise the header z-index, center the profile/search overlays, and restore the full-screen backdrop
- restyle reservation tables with the darker palette and refreshed pagination controls

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4341200b483209b3dada0b6d4010c