### PR TITLE
Adjust search modal layout for mobile

### DIFF
--- a/components/layout/Header.vue
+++ b/components/layout/Header.vue
@@ -92,8 +92,8 @@
             class="fixed inset-0 z-50 flex min-h-screen items-center justify-center bg-slate-950/80 px-4 py-12 text-slate-100 backdrop-blur-xl"
             @click.self="closeInput"
         >
-          <div class="relative w-full max-w-2xl rounded-3xl border border-white/10 bg-slate-900/85 p-6 shadow-2xl shadow-indigo-500/20 backdrop-blur-2xl sm:p-8">
-            <button @click="closeInput" class="absolute right-6 top-6 text-slate-300 transition hover:text-indigo-200">
+          <div class="relative w-full max-w-2xl rounded-3xl border border-white/10 bg-slate-900/85 p-5 shadow-2xl shadow-indigo-500/20 backdrop-blur-2xl sm:p-8 max-h-[75vh] overflow-y-auto sm:max-h-none sm:overflow-visible">
+            <button @click="closeInput" class="absolute right-4 top-4 text-slate-300 transition hover:text-indigo-200 sm:right-6 sm:top-6">
               <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
               </svg>
@@ -105,7 +105,7 @@
                     v-model="searchQuery"
                     type="text"
                     placeholder="Поиск книг..."
-                    class="flex-1 rounded-full border border-white/10 bg-slate-900/60 p-4 pr-24 text-base text-slate-100 transition placeholder:text-slate-400 focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-300"
+                    class="w-full max-w-[18rem] rounded-full border border-white/10 bg-slate-900/60 p-4 pr-24 text-base text-slate-100 transition placeholder:text-slate-400 focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-300 sm:max-w-none sm:flex-1"
                     @keyup.enter="onSearch"
                     autofocus
                 />
@@ -145,11 +145,11 @@
                   </label>
 
                   <!-- Иконка с подсказкой -->
-                  <div class="group relative">
+                  <div class="group relative inline-flex">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 cursor-help text-indigo-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
                     </svg>
-                    <div class="absolute bottom-full left-1/2 z-10 w-64 -translate-x-1/2 rounded-2xl border border-white/10 bg-slate-900/90 px-4 py-3 text-xs text-slate-100 opacity-0 shadow-xl shadow-indigo-500/20 backdrop-blur-xl transition-all duration-200 group-hover:visible group-hover:translate-y-[-4px] group-hover:opacity-100 sm:text-sm">
+                    <div class="pointer-events-none absolute bottom-full left-1/2 z-10 w-48 -translate-x-1/2 rounded-2xl border border-white/10 bg-slate-900/90 px-3 py-2 text-xs text-slate-100 opacity-0 shadow-xl shadow-indigo-500/20 backdrop-blur-xl transition-all duration-200 group-hover:visible group-hover:translate-y-[-4px] group-hover:opacity-100 sm:w-64 sm:px-4 sm:py-3 sm:text-sm">
                       Включает продвинутый поиск. Вы можете написать описание книги, и система подберёт книги с помощью ИИ.
                       <div class="absolute top-full left-1/2 -translate-x-1/2 h-3 w-3 rotate-45 border-r border-b border-white/10 bg-slate-900/90"></div>
                     </div>


### PR DESCRIPTION
## Summary
- limit the search modal height on small screens and adjust padding for better fit
- narrow the search input on mobile while keeping the desktop layout unchanged
- shrink the tooltip hover area and close button offsets to avoid blocking interactions

## Testing
- npm run dev -- --host 0.0.0.0 --port 3000

------
https://chatgpt.com/codex/tasks/task_e_68e64e19e82c8320a8e7b8d8b1d1998a