### PR TITLE
Adjust profile reviews slider responsiveness

### DIFF
--- a/components/profile/Reviews.vue
+++ b/components/profile/Reviews.vue
@@ -12,6 +12,20 @@ const swiper = useSwiper(containerRef, {
   },
   spaceBetween: 20,
   slidesPerView: 3,
+  breakpoints: {
+    0: {
+      slidesPerView: 1
+    },
+    640: {
+      slidesPerView: 1
+    },
+    768: {
+      slidesPerView: 2
+    },
+    1024: {
+      slidesPerView: 3
+    }
+  },
   direction: 'horizontal',
 })
 const wordCut = (string: string) => {
@@ -34,7 +48,10 @@ const wordCut = (string: string) => {
             v-for="(slide, idx) in array"
             :key="idx"
         >
-          <div class="review-card">
+          <NuxtLink
+              class="review-card"
+              :to="`/books/${slide.book_id}`"
+          >
             <div class="book-title">{{ slide.book_title }}</div>
             <div class="review-content">{{ wordCut(slide.content) }}</div>
             <div class="review-footer">
@@ -44,7 +61,7 @@ const wordCut = (string: string) => {
                 <span class="dislikes">👎 {{ slide.dislikes }}</span>
               </div>
             </div>
-          </div>
+          </NuxtLink>
         </swiper-slide>
       </swiper-container>
     </div>
@@ -72,6 +89,7 @@ const wordCut = (string: string) => {
   flex-direction: column;
   transition: all 0.3s ease;
   border: 1px solid #e0e7ff;
+  text-decoration: none;
 }
 
 .review-card:hover {

--- a/components/profile/UserInfo.vue
+++ b/components/profile/UserInfo.vue
@@ -43,23 +43,23 @@ const getBackgroundStyle = () => {
 
 <template>
   <div class="flex flex-col items-center justify-center p-10 rounded-3xl bg-user-main" :style="getBackgroundStyle()">
-    <div class="bg-user px-20 py-10">
+    <div class="bg-user px-20 py-10 text-gray-900">
       <div class="text-center flex flex-col justify-center items-center">
         <img src="/img/img1.jpg" alt="User avatar" class="mb-5" /> <!-- Обновил путь и добавил alt -->
-        <p class="text-xl font-bold">{{ name }}</p>
-        <span>Уровень: 1</span>
+        <p class="text-xl font-bold text-gray-900">{{ name }}</p>
+        <span class="text-gray-700">Уровень: 1</span>
       </div>
-      <div class="text-center">
+      <div class="text-center text-gray-800">
         <p>Количество прочитанных книг: {{ totalBooks }}</p>
-        <p :class="isCurrentUser ? 'mb-10' : ''">С нами с: {{ formatDate(registerDate) }}</p>
+        <p :class="['text-gray-800', isCurrentUser ? 'mb-10' : '']">С нами с: {{ formatDate(registerDate) }}</p>
         <span class="bg-red-500 hover:bg-red-600 py-2 px-5 rounded-md text-white cursor-pointer" v-if="isCurrentUser">Выйти</span>
       </div>
     </div>
   </div>
   <div class="my-20">
     <h2 class="text-center text-2xl mb-10">Рецензии пользователя</h2>
-    <reviews v-if="array" :array="array" />
-    <h2 class="text-center text-xl mb-10">У пользователя нет рецензий(</h2>
+    <reviews v-if="array && array.length" :array="array" />
+    <h2 v-else class="text-center text-xl mb-10">У пользователя нет рецензий(</h2>
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
- add responsive breakpoints to the profile reviews swiper and link each review card to the related book
- update profile card text colors for better contrast against the light background
- hide the empty state message unless the user truly has no reviews

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e673f48d1083208cd56361c94121c8