### PR TITLE
Improve book page user handling and auth form visibility

### DIFF
--- a/components/books/BooksPageItem.vue
+++ b/components/books/BooksPageItem.vue
@@ -37,6 +37,10 @@ const editedReview = ref('');
 const isProcessingDeletion = ref(false);
 
 const isAdmin = computed(() => globalStore.currentUser?.role === 'Admin');
+const currentUserId = computed(() => Number(globalStore.currentUser?.id ?? 0));
+const canManageReview = (reviewUserId) => {
+  return currentUserId.value === Number(reviewUserId ?? 0);
+};
 
 const toggleFavorite = async () => {
   if (!globalStore.isAuthenticated) {
@@ -332,7 +336,7 @@ const handleDelete = async () => {
               </div>
 
               <div
-                  v-if="store.currentUser.id === review.user_id"
+                  v-if="canManageReview(review.user_id)"
                   class="flex gap-2"
               >
                 <button

--- a/components/profile/UserInfo.vue
+++ b/components/profile/UserInfo.vue
@@ -42,8 +42,11 @@ const getBackgroundStyle = () => {
 </script>
 
 <template>
-  <div class="flex flex-col items-center justify-center p-10 rounded-3xl bg-user-main" :style="getBackgroundStyle()">
-    <div class="bg-user px-20 py-10 text-gray-900">
+  <div
+    class="flex flex-col items-center justify-center rounded-3xl bg-user-main p-6 sm:p-10"
+    :style="getBackgroundStyle()"
+  >
+    <div class="bg-user w-full max-w-xs px-6 py-8 text-gray-900 sm:max-w-2xl sm:px-20 sm:py-10">
       <div class="text-center flex flex-col justify-center items-center">
         <img src="/img/img1.jpg" alt="User avatar" class="mb-5" /> <!-- Обновил путь и добавил alt -->
         <p class="text-xl font-bold text-gray-900">{{ name }}</p>

--- a/pages/auth/login.vue
+++ b/pages/auth/login.vue
@@ -85,6 +85,12 @@ const onLogin = async () => {
         border-radius: 20px;
         border: 1px solid #2C3E50;
         font-size: 16px;
+        color: #1f2937;
+        background-color: #ffffff;
+      }
+
+      input::placeholder {
+        color: #6b7280;
       }
     }
 

--- a/pages/auth/register.vue
+++ b/pages/auth/register.vue
@@ -126,6 +126,12 @@ const onRegistr = async () => {
         border-radius: 20px;
         border: 1px solid #2C3E50;
         font-size: 16px;
+        color: #1f2937;
+        background-color: #ffffff;
+      }
+
+      input::placeholder {
+        color: #6b7280;
       }
     }
 

--- a/pages/books/[id]/index.vue
+++ b/pages/books/[id]/index.vue
@@ -4,6 +4,7 @@ import {useBookStore} from "~/stores/book";
 import { useRoute } from 'vue-router';
 import {fetchBookById} from "~/composables/useBook";
 import {useCommentsStore} from "~/stores/comments";
+import { useFavoriteStore } from "~/stores/favorite";
 const book = ref(null);
 const route = useRoute(); // Получаем объект маршрута
 const id = ref(Number(route.params.id)); // Извлекаем ID из параметров маршрута


### PR DESCRIPTION
## Summary
- make the profile header card responsive on small screens so the background panel no longer overflows
- ensure the book details page safely handles the current user by defaulting to id 0 and only allowing comment actions for the owner
- improve login and registration forms by giving inputs dark text and proper placeholder contrast

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e67f8ed70883208cdb4dc5a77f4370